### PR TITLE
Billing 1728

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build/
 
 ### Mac OS ###
 .DS_Store
+/.idea/inspectionProfiles/Project_Default.xml

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -76,21 +76,22 @@ public class ClientesController implements Controller {
 
         if (clienteExistente == null) {
             return "CPF não cadastrado";
-        } else {
-            System.out.println("Nome: [" + clienteExistente.getNomeCompleto() + "]");
-            String nomeCompleto = scanner.nextLine();
-
-            if (nomeCompleto.isEmpty()) {
-                nomeCompleto = clienteExistente.getNomeCompleto();
-            }
-
-            System.out.println("Endereço: [" + clienteExistente.getEndereco() + "]");
-            String endereco = scanner.nextLine();
-            if (endereco.isEmpty()) {
-                endereco = clienteExistente.getEndereco();
-            }
-
-            return clienteService.atualizarCliente(nomeCompleto, cpf, endereco);
         }
+
+        System.out.println("Nome: [" + clienteExistente.getNomeCompleto() + "]");
+        String nomeCompleto = scanner.nextLine();
+
+        if (nomeCompleto.isEmpty()) {
+            nomeCompleto = clienteExistente.getNomeCompleto();
+        }
+
+        System.out.println("Endereço: [" + clienteExistente.getEndereco() + "]");
+        String endereco = scanner.nextLine();
+
+        if (endereco.isEmpty()) {
+            endereco = clienteExistente.getEndereco();
+        }
+
+        return clienteService.atualizarCliente(nomeCompleto, cpf, endereco);
     }
 }

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -27,6 +27,7 @@ public class ClientesController implements Controller {
                     | pesquisar                  |
                     ------------------------------""";
         }
+
         String[] partes = comando.split(" ");
         var acao = partes[1];
 

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -18,7 +18,6 @@ public class ClientesController implements Controller {
     }
 
     public String executar(String comando) {
-
         if (comando.equals("clientes")) {
             return """
                     ------------------------------
@@ -83,7 +82,6 @@ public class ClientesController implements Controller {
     }
 
     private String pesquisarCliente(String[] partes) {
-
         if (partes.length == 2) {
             return """
                     --------------------------

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -18,37 +18,35 @@ public class ClientesController implements Controller {
     }
 
     public String executar(String comando) {
-        switch (comando) {
-            case "clientes":
-                return """
-                        ------------------------------
-                        | atualizar {cpf do cliente} |
-                        | cadastrar                  |
-                        | desativar {cpf do cliente} |
-                        | pesquisar                  |
-                        ------------------------------""";
 
-            case "clientes atualizar":
-                return atualizarCliente();
+        if (comando.equals("clientes")) {
+            return """
+                    ------------------------------
+                    | atualizar {cpf do cliente} |
+                    | cadastrar                  |
+                    | desativar {cpf do cliente} |
+                    | pesquisar                  |
+                    ------------------------------""";
+        }
+        String[] partes = comando.split(" ");
+        var acao = partes[1];
 
-            case "clientes cadastrar":
+        switch (acao) {
+            case "atualizar":
+                if (partes.length == 3) {
+                    return atualizarCliente(partes[2]);
+                } else {
+                    return "Para atualizar é necessário informar o CPF. Ex: clientes atualizar 12345678901";
+                }
+
+            case "cadastrar":
                 return cadastrarCliente();
 
-            case "clientes desativar":
+            case "desativar":
                 return "não implementado";
 
-            case "clientes pesquisar":
-                return """
-                        --------------------------
-                        | cpf {cpf do cliente}   |
-                        | nome {nome do cliente} |
-                        -------------------------""";
-
-            case "clientes pesquisar cpf":
-                return "não implementado";
-
-            case "clientes pesquisar nome":
-                return "não implementado";
+            case "pesquisar":
+                return pesquisarCliente(partes);
 
             default:
                 return "operação inválida";
@@ -68,10 +66,7 @@ public class ClientesController implements Controller {
         return clienteService.cadastrarCliente(nomeCompleto, cpf, endereco);
     }
 
-    public String atualizarCliente() {
-        System.out.println("Informe seu CPF: ");
-        String cpf = scanner.nextLine();
-
+    public String atualizarCliente(String cpf) {
         Cliente clienteExistente = clienteService.buscarClientePorCPF(cpf);
 
         if (clienteExistente == null) {
@@ -85,5 +80,27 @@ public class ClientesController implements Controller {
         String endereco = scanner.nextLine();
 
         return clienteService.atualizarCliente(nomeCompleto, cpf, endereco);
+    }
+
+    private String pesquisarCliente(String[] partes) {
+
+        if (partes.length == 2) {
+            return """
+                    --------------------------
+                    | cpf {cpf do cliente}   |
+                    | nome {nome do cliente} |
+                    -------------------------""";
+        }
+
+        switch (partes[2]) {
+            case "cpf":
+                return "não implementado";
+
+            case "nome":
+                return "não implementado";
+
+            default:
+                return "operação inválida";
+        }
     }
 }

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -81,16 +81,8 @@ public class ClientesController implements Controller {
         System.out.println("Nome: [" + clienteExistente.getNomeCompleto() + "]");
         String nomeCompleto = scanner.nextLine();
 
-        if (nomeCompleto.isEmpty()) {
-            nomeCompleto = clienteExistente.getNomeCompleto();
-        }
-
         System.out.println("Endereço: [" + clienteExistente.getEndereco() + "]");
         String endereco = scanner.nextLine();
-
-        if (endereco.isEmpty()) {
-            endereco = clienteExistente.getEndereco();
-        }
 
         return clienteService.atualizarCliente(nomeCompleto, cpf, endereco);
     }

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -29,7 +29,7 @@ public class ClientesController implements Controller {
                         ------------------------------""";
 
             case "clientes atualizar":
-                return "não implementado";
+                return atualizarCliente();
 
             case "clientes cadastrar":
                 return cadastrarCliente();
@@ -66,5 +66,31 @@ public class ClientesController implements Controller {
         String endereco = scanner.nextLine();
 
         return clienteService.cadastrarCliente(nomeCompleto, cpf, endereco);
+    }
+
+    public String atualizarCliente() {
+        System.out.println("Informe seu CPF: ");
+        String cpf = scanner.nextLine();
+
+        Cliente clienteExistente = clienteService.buscarClientePorCPF(cpf);
+
+        if (clienteExistente == null) {
+            return "CPF não cadastrado";
+        } else {
+            System.out.println("Nome: [" + clienteExistente.getNomeCompleto() + "]");
+            String nomeCompleto = scanner.nextLine();
+
+            if (nomeCompleto.isEmpty()) {
+                nomeCompleto = clienteExistente.getNomeCompleto();
+            }
+
+            System.out.println("Endereço: [" + clienteExistente.getEndereco() + "]");
+            String endereco = scanner.nextLine();
+            if (endereco.isEmpty()) {
+                endereco = clienteExistente.getEndereco();
+            }
+
+            return clienteService.atualizarCliente(nomeCompleto, cpf, endereco);
+        }
     }
 }

--- a/src/main/java/org/example/service/ClienteService.java
+++ b/src/main/java/org/example/service/ClienteService.java
@@ -6,4 +6,6 @@ public interface ClienteService {
     String cadastrarCliente(String nomeCompleto, String cpf, String endereco);
 
     Cliente buscarClientePorCPF(String cpf);
+
+    String atualizarCliente(String nomeCompleto, String cpf, String endereco);
 }

--- a/src/main/java/org/example/service/ClienteServiceImpl.java
+++ b/src/main/java/org/example/service/ClienteServiceImpl.java
@@ -35,6 +35,19 @@ public class ClienteServiceImpl implements ClienteService {
 
     @Override
     public String atualizarCliente(String nomeCompleto, String cpf, String endereco) {
+        Cliente clienteExistente = buscarClientePorCPF(cpf);
+
+        if (clienteExistente == null) {
+            return "CPF não cadastrado";
+        }
+
+        if (nomeCompleto.isEmpty()) {
+            nomeCompleto = clienteExistente.getNomeCompleto();
+        }
+
+        if (endereco.isEmpty()) {
+            endereco = clienteExistente.getEndereco();
+        }
 
         //Cria um novo cliente do tipo cliente com os dados fornecidos
         listaClientes.put(cpf, new Cliente(nomeCompleto, cpf, endereco));

--- a/src/main/java/org/example/service/ClienteServiceImpl.java
+++ b/src/main/java/org/example/service/ClienteServiceImpl.java
@@ -32,5 +32,17 @@ public class ClienteServiceImpl implements ClienteService {
 
         return listaClientes.get(cpf);
     }
+
+    @Override
+    public String atualizarCliente(String nomeCompleto, String cpf, String endereco) {
+
+//        if (!listaClientes.containsKey(cpf)) {
+//            return "CPF não encontrado";
+//        }
+        //Cria um novo cliente do tipo cliente com os dados fornecidos
+        listaClientes.put(cpf, new Cliente(nomeCompleto, cpf, endereco));
+
+        return "Dados atualizados com sucesso";
+    }
 }
 

--- a/src/main/java/org/example/service/ClienteServiceImpl.java
+++ b/src/main/java/org/example/service/ClienteServiceImpl.java
@@ -36,13 +36,10 @@ public class ClienteServiceImpl implements ClienteService {
     @Override
     public String atualizarCliente(String nomeCompleto, String cpf, String endereco) {
 
-//        if (!listaClientes.containsKey(cpf)) {
-//            return "CPF não encontrado";
-//        }
         //Cria um novo cliente do tipo cliente com os dados fornecidos
         listaClientes.put(cpf, new Cliente(nomeCompleto, cpf, endereco));
 
-        return "Dados atualizados com sucesso";
+        return "Cliente atualizado com sucesso";
     }
 }
 

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -61,12 +61,12 @@ public class ClientesControllerIntegrationTest {
     }
 
     @Test
-    public void quandoComandoEhClientesAtualizarEntaoNaoAtualizeOsClientes() {
+    public void quandoComandoEhClientesAtualizarECpfNaoForCadastradoEntaoNaoAtualizeOCLiente() {
         this.inputStream.setInputs("Kevelly\n0123456789\nRua Fictícia 123\n");
         controller.executar("clientes cadastrar");
 
         // arrange
-        this.inputStream.setInputs("0000000000\nKevelly\nRua Teste 234\n");
+        this.inputStream.setInputs("0000000000\n");
         var resultadoEsperado = "CPF não cadastrado";
 
         // act

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -61,6 +61,22 @@ public class ClientesControllerIntegrationTest {
     }
 
     @Test
+    public void quandoComandoEhClientesAtualizarEntaoNaoAtualizeOsClientes() {
+        this.inputStream.setInputs("Kevelly\n0123456789\nRua Fictícia 123\n");
+        controller.executar("clientes cadastrar");
+
+        // arrange
+        this.inputStream.setInputs("0000000000\nKevelly\nRua Teste 234\n");
+        var resultadoEsperado = "CPF não cadastrado";
+
+        // act
+        var resultadoReal = controller.executar("clientes atualizar");
+
+        // assert
+        assertEquals(resultadoEsperado, resultadoReal);
+    }
+
+    @Test
     public void quandoComandoEhClientesCadastrarEntaoCadastreOsClientes() {
         //o \n é um delimitador para o Scanner(espaço e tabulação também),
         //sempre q ele lê sabe acabou e passa para a próxima linha

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.example.controller;
 
 import java.util.Scanner;
+
 import org.example.service.ClienteService;
 import org.example.service.ClienteServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,17 @@ public class ClientesControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhClientesAtualizarEntaoAtualizeOsClientes() {
-        var resultadoEsperado = "não implementado";
+        clienteService.cadastrarCliente("Kevelly", "0123456789", "Rua Fictícia 123");
+        this.inputStream.setInputs("0123456789\n");
+
+        var cliente = clienteService.buscarClientePorCPF("0123456789");
+        assertEquals("Kevelly", cliente.getNomeCompleto());
+        assertEquals("0123456789", cliente.getCpf());
+        assertEquals("Rua Fictícia 123", cliente.getEndereco());
+
+        this.inputStream.setInputs("Kevelly\nRua Fictícia 123\n");
+
+        var resultadoEsperado = "Cliente atualizado com sucesso";
         var resultadoReal = controller.executar("clientes atualizar");
         assertEquals(resultadoEsperado, resultadoReal);
     }

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -42,19 +42,22 @@ public class ClientesControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhClientesAtualizarEntaoAtualizeOsClientes() {
-        clienteService.cadastrarCliente("Kevelly", "0123456789", "Rua Fictícia 123");
-        this.inputStream.setInputs("0123456789\n");
+        this.inputStream.setInputs("Kevelly\n0123456789\nRua Fictícia 123\n");
+        controller.executar("clientes cadastrar");
 
+        // arrange
+        this.inputStream.setInputs("0123456789\nKevelly\nRua Teste 234\n");
+        var resultadoEsperado = "Cliente atualizado com sucesso";
+
+        // act
+        var resultadoReal = controller.executar("clientes atualizar");
+
+        // assert
+        assertEquals(resultadoEsperado, resultadoReal);
         var cliente = clienteService.buscarClientePorCPF("0123456789");
         assertEquals("Kevelly", cliente.getNomeCompleto());
         assertEquals("0123456789", cliente.getCpf());
-        assertEquals("Rua Fictícia 123", cliente.getEndereco());
-
-        this.inputStream.setInputs("Kevelly\nRua Fictícia 123\n");
-
-        var resultadoEsperado = "Cliente atualizado com sucesso";
-        var resultadoReal = controller.executar("clientes atualizar");
-        assertEquals(resultadoEsperado, resultadoReal);
+        assertEquals("Rua Teste 234", cliente.getEndereco());
     }
 
     @Test

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -46,11 +46,11 @@ public class ClientesControllerIntegrationTest {
         controller.executar("clientes cadastrar");
 
         // arrange
-        this.inputStream.setInputs("0123456789\nKevelly\nRua Teste 234\n");
+        this.inputStream.setInputs("Kevelly\nRua Teste 234\n");
         var resultadoEsperado = "Cliente atualizado com sucesso";
 
         // act
-        var resultadoReal = controller.executar("clientes atualizar");
+        var resultadoReal = controller.executar("clientes atualizar 0123456789");
 
         // assert
         assertEquals(resultadoEsperado, resultadoReal);
@@ -66,8 +66,19 @@ public class ClientesControllerIntegrationTest {
         controller.executar("clientes cadastrar");
 
         // arrange
-        this.inputStream.setInputs("0000000000\n");
         var resultadoEsperado = "CPF não cadastrado";
+
+        // act
+        var resultadoReal = controller.executar("clientes atualizar 0000000000");
+
+        // assert
+        assertEquals(resultadoEsperado, resultadoReal);
+    }
+
+    @Test
+    public void quandoComandoEhClientesAtualizarECpfNaoEhInformadoEntaoRetorneErro() {
+        // arrange
+        var resultadoEsperado = "Para atualizar é necessário informar o CPF. Ex: clientes atualizar 12345678901";
 
         // act
         var resultadoReal = controller.executar("clientes atualizar");
@@ -80,7 +91,7 @@ public class ClientesControllerIntegrationTest {
     public void quandoComandoEhClientesCadastrarEntaoCadastreOsClientes() {
         //o \n é um delimitador para o Scanner(espaço e tabulação também),
         //sempre q ele lê sabe acabou e passa para a próxima linha
-        this.inputStream.setInputs("Kevelly\n0123456789\nRua Fictícia 123\n");
+        this.inputStream.setInputs("Kevelly\n0123456789\nRua Ficticia 123\n");
 
         var resultadoEsperado = "Cliente cadastrado com sucesso";
         var resultadoReal = controller.executar("clientes cadastrar");
@@ -89,7 +100,7 @@ public class ClientesControllerIntegrationTest {
         var cliente = clienteService.buscarClientePorCPF("0123456789");
         assertEquals("Kevelly", cliente.getNomeCompleto());
         assertEquals("0123456789", cliente.getCpf());
-        assertEquals("Rua Fictícia 123", cliente.getEndereco());
+        assertEquals("Rua Ficticia 123", cliente.getEndereco());
     }
 
     @Test

--- a/src/test/java/org/example/controller/TesteInputStream.java
+++ b/src/test/java/org/example/controller/TesteInputStream.java
@@ -2,8 +2,6 @@ package org.example.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 public class TesteInputStream extends InputStream {
     private String input;
@@ -22,17 +20,6 @@ public class TesteInputStream extends InputStream {
         }
 
         //Pega o caractere atual da String e add mais um ao indice
-        char caractere =  input.charAt(indiceMaisRecente++);
-
-        //char sendo convertido diretamente em int (type casting explícito - maior para menor)
-        return (int) caractere;
-
-        //Não daria certo porque o inputStrem retorna valores de 0 a 255, transformar em bytes gera valores invalidos
-        //var bytes = String.valueOf(this.input.charAt(indiceMaisRecente)).getBytes(StandardCharsets.UTF_8);
-        //indiceMaisRecente++;
-        //ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
-        //buffer.put(bytes);
-        //buffer.rewind();
-        //return buffer.getInt();
+        return input.charAt(indiceMaisRecente++);
     }
 }

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -54,14 +54,15 @@ public class ClienteServiceImplTest {
                 "Joao",
                 "5689778",
                 "Rua dos testes 123");
-        var resultadoEsperado = "CPF já cadastrado";
 
+        var resultadoEsperado = "CPF já cadastrado";
         assertEquals(resultadoEsperado, resultado);
     }
 
     @Test
     public void quandoBuscarClientePorCpfEntaoVerifiqueSeCadastrouChaveAntes() {
         clienteServiceImpl.cadastrarCliente("Kevelly", "5689778", "Rua teste");
+
         var resultado = clienteServiceImpl.cadastrarCliente(
                 "Kevelly",
                 "5689778",
@@ -87,7 +88,6 @@ public class ClienteServiceImplTest {
                 "Rua teste da silva");
 
         var resultadoEsperado = "Cliente atualizado com sucesso";
-
         assertEquals(resultadoEsperado, resultado);
 
         Cliente cliente = clienteServiceImpl.buscarClientePorCPF("5689778");
@@ -96,7 +96,6 @@ public class ClienteServiceImplTest {
         assertEquals("5689778", cliente.getCpf());
         assertEquals("Rua teste da silva", cliente.getEndereco());
     }
-
 
     @ParameterizedTest
     //permite executar o mesmo teste várias vezes com valores diferentes

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -38,7 +38,7 @@ public class ClienteServiceImplTest {
 
     @ParameterizedTest
     @NullAndEmptySource //quando a função for executada passa null e depois vazia
-    public void quandoBuscarClientePorCpfForVaziaEntaoCadastra(String cpf) {
+    public void quandoBuscarClientePorCpfForVazioOuNuloEntaoNaoRealizarCadastro(String cpf) {
         var resultado = clienteServiceImpl.cadastrarCliente("Kevelly", cpf, "Rua teste");
         Cliente cliente = clienteServiceImpl.buscarClientePorCPF(cpf);
 

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -4,6 +4,7 @@ import org.example.model.Cliente;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,6 +24,7 @@ public class ClienteServiceImplTest {
                 "Kevelly",
                 "5689778",
                 "Rua teste");
+
         Cliente cliente = clienteServiceImpl.buscarClientePorCPF("5689778");
 
         var resultadoEsperado = "Cliente cadastrado com sucesso";
@@ -36,12 +38,25 @@ public class ClienteServiceImplTest {
 
     @ParameterizedTest
     @NullAndEmptySource //quando a função for executada passa null e depois vazia
-    public void quandoBuscarClientePorCpfForVaziaEntaoNaoCadastra(String cpf) {
+    public void quandoBuscarClientePorCpfForVaziaEntaoCadastra(String cpf) {
         var resultado = clienteServiceImpl.cadastrarCliente("Kevelly", cpf, "Rua teste");
         Cliente cliente = clienteServiceImpl.buscarClientePorCPF(cpf);
 
         assertEquals("CPF não pode ser nulo ou vazio", resultado);
         assertNull(cliente);
+    }
+
+    @Test
+    public void quandoBuscarClientePorCpfForVaziaEntaoNaoCadastra() {
+        quandoCadastrarClienteVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso();
+
+        var resultado = clienteServiceImpl.cadastrarCliente(
+                "Joao",
+                "5689778",
+                "Rua dos testes 123");
+        var resultadoEsperado = "CPF já cadastrado";
+
+        assertEquals(resultadoEsperado, resultado);
     }
 
     @Test
@@ -59,5 +74,70 @@ public class ClienteServiceImplTest {
     public void quandoBuscarClientePorCpfECpfNaoExistirEntaoRetorneNulo() {
         Cliente cliente = clienteServiceImpl.buscarClientePorCPF("");
         assertNull(cliente);
+    }
+
+    //TESTE ATUALIZAR
+    @Test
+    public void quandoAtualizarClienteVerifiqueSeOCpfJaFoiAtualizadoEntaoAtualizeComSucesso() {
+        quandoCadastrarClienteVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso();
+
+        var resultado = clienteServiceImpl.atualizarCliente(
+                "Joana",
+                "5689778",
+                "Rua teste da silva");
+
+        var resultadoEsperado = "Cliente atualizado com sucesso";
+
+        assertEquals(resultadoEsperado, resultado);
+
+        Cliente cliente = clienteServiceImpl.buscarClientePorCPF("5689778");
+        assertNotNull(cliente);
+        assertEquals("Joana", cliente.getNomeCompleto());
+        assertEquals("5689778", cliente.getCpf());
+        assertEquals("Rua teste da silva", cliente.getEndereco());
+    }
+
+
+    @ParameterizedTest
+    //permite executar o mesmo teste várias vezes com valores diferentes
+    //Simula a entrada vazia, esperando que o nome continue "Kevelly"
+    @CsvSource({" , Kevelly"})
+    public void quandoAtualizarClienteVerfiqueSeNomeCompletoEhVazioEntaoRetorneSeuValorAnterior(
+            String novoNome,
+            String nomeEsperado
+    ) {
+        clienteServiceImpl.cadastrarCliente("Kevelly", "5689778", "Rua teste");
+        Cliente cliente = clienteServiceImpl.buscarClientePorCPF("5689778");
+
+        //Simula o input vazio
+        if (novoNome == null) {
+            novoNome = cliente.getNomeCompleto();
+        }
+
+        clienteServiceImpl.atualizarCliente(novoNome, "5689778", "Rua teste");
+
+        //Valida se o nome continua o mesmo
+        Cliente clienteAtualizado = clienteServiceImpl.buscarClientePorCPF("5689778");
+        assertEquals(nomeEsperado, clienteAtualizado.getNomeCompleto());
+    }
+
+    @ParameterizedTest
+    //permite executar o mesmo teste várias vezes com valores diferentes
+    @CsvSource({" , rua Unitarios 123"})
+    public void quandoAtualizarClienteVerfiqueSeEnderecoEhVazioEntaoRetorneSeuValorAnterior(
+            String novoEndereco,
+            String enderecoEsperado
+    ) {
+        clienteServiceImpl.cadastrarCliente("Kevelly", "5689778", "rua Unitarios 123");
+        Cliente cliente = clienteServiceImpl.buscarClientePorCPF("5689778");
+
+        if (novoEndereco == null) {
+            novoEndereco = cliente.getEndereco();
+        }
+
+        clienteServiceImpl.atualizarCliente("Ana", "5689778", novoEndereco);
+
+        Cliente clienteAtualizado = clienteServiceImpl.buscarClientePorCPF("5689778");
+        assertEquals(enderecoEsperado, clienteAtualizado.getEndereco());
     }
 }


### PR DESCRIPTION
Atualizar informação de um cliente

Descrição

Como usuário do sistema,
Quero atualizar os detalhes de um cliente existente
Para que eu possa manter suas informações atualizadas.

Comando: clientes atualizar {CPF}

Critérios de aceitação:

Comando deve receber CPF como parâmetro

Se o CPF não for encontrado, exibir mensagem apropriada

Se encontrar o CPF, solicitar a digitação de cada campo do cliente um a um, exibindo entre colchetes o valor atual. Ex.:
Nome: [Fulano da Silva]
Se o usuário digitar qualquer coisa e teclar Enter, sobrescreve com o que o usuário digitou
Mas se o usuário não digitar nada e só teclar Enter, não sobrescreve, mas mantém o valor atual e solicita o próximo campo

Apenas nome completo e endereço podem ser atualizados (CPF permanece inalterado).

O sistema deve confirmar a atualização.

Testes unitários escritos usando JUnit

Testes de integração