### PR TITLE
Feature/billing 1731

### DIFF
--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -106,6 +106,7 @@ public class ClientesController implements Controller {
 
     public String pesquisarClientesPorNome(String nome) {
         List<Cliente> clientes = clienteService.pesquisarClientePorNome(nome);
+        // String clientes2 = clientes.toString();
 
         if (clientes.isEmpty()) {
             return "Nenhum cliente com esse nome foi encontrado.";

--- a/src/main/java/org/example/controller/ClientesController.java
+++ b/src/main/java/org/example/controller/ClientesController.java
@@ -94,7 +94,7 @@ public class ClientesController implements Controller {
 
         switch (partes[2]) {
             case "cpf":
-                return "não implementado";
+                return pesquisarClientesPorCPF(partes[3]);
 
             case "nome":
                 return pesquisarClientesPorNome(partes[3]);
@@ -117,5 +117,18 @@ public class ClientesController implements Controller {
         }
 
         return resultado.toString();
+    }
+
+    public String pesquisarClientesPorCPF(String cpf) {
+        Cliente cliente = clienteService.pesquisarClientePorCPF(cpf);
+
+        if (cliente == null) {
+            return "Nenhum cliente com esse CPF foi encontrado.";
+        }
+
+        String resultado = "Cliente encontrado: \n";
+        resultado += cliente + "\n";
+
+        return resultado;
     }
 }

--- a/src/main/java/org/example/service/ClienteService.java
+++ b/src/main/java/org/example/service/ClienteService.java
@@ -12,4 +12,6 @@ public interface ClienteService {
     String atualizarCliente(String nomeCompleto, String cpf, String endereco);
 
     List<Cliente> pesquisarClientePorNome(String nome);
+
+    Cliente pesquisarClientePorCPF(String cpf);
 }

--- a/src/main/java/org/example/service/ClienteServiceImpl.java
+++ b/src/main/java/org/example/service/ClienteServiceImpl.java
@@ -71,5 +71,16 @@ public class ClienteServiceImpl implements ClienteService {
 
         return clientesEncontrados;
     }
+
+    @Override
+    public Cliente pesquisarClientePorCPF(String cpf) {
+        Cliente cliente = buscarClientePorCPF(cpf);
+
+        if (listaClientes.containsKey(cpf)) {
+            return cliente;
+        }
+
+        return null;
+    }
 }
 

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -156,5 +156,29 @@ public class ClientesControllerIntegrationTest {
         var resultadoReal = controller.executar("clientes pesquisar nome Kevelly");
         assertEquals(resultadoEsperado, resultadoReal);
     }
+
+    @Test
+    public void quandoComandoEhClientesPesquisarCpfEEncontrarClienteEntaoSuasInformacoes() {
+        quandoComandoEhClientesCadastrarEntaoCadastreOsClientes();
+
+        clienteService.pesquisarClientePorCPF("0123456789");
+
+        var resultadoEsperado = "Cliente encontrado: \n" +
+                "Cliente(nomeCompleto=Kevelly, cpf=0123456789, endereco=Rua Ficticia 123)\n";
+
+        var resultadoReal = controller.executar("clientes pesquisar cpf 0123456789");
+        assertEquals(resultadoEsperado, resultadoReal);
+    }
+
+    @Test
+    public void quandoComandoEhClientesPesquisarCpfENaoEncontrarUmClienteEntaoRetorneErro() {
+        clienteService.pesquisarClientePorCPF("0123456789");
+
+        var resultadoEsperado = "Nenhum cliente com esse CPF foi encontrado.";
+
+        var resultadoReal = controller.executar("clientes pesquisar cpf 0123456789");
+        assertEquals(resultadoEsperado, resultadoReal);
+    }
+
 }
 

--- a/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClientesControllerIntegrationTest.java
@@ -158,7 +158,7 @@ public class ClientesControllerIntegrationTest {
     }
 
     @Test
-    public void quandoComandoEhClientesPesquisarCpfEEncontrarClienteEntaoSuasInformacoes() {
+    public void quandoComandoEhClientesPesquisarCpfEEncontrarClienteEntaoRetorneSuasInformacoes() {
         quandoComandoEhClientesCadastrarEntaoCadastreOsClientes();
 
         clienteService.pesquisarClientePorCPF("0123456789");

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -162,10 +162,21 @@ public class ClienteServiceImplTest {
         assertTrue(resultado
                 .stream()  // Stream transforma a lista em um fluxo de dados
                 .allMatch( // Verifica se todos os elementos da lista atendem à condição.
-                           // Para cada cliente na lista, compara o nome do cliente
-                           // e ignora as diferenças entre maiusculas e minusculas
+                        // Para cada cliente na lista, compara o nome do cliente
+                        // e ignora as diferenças entre maiusculas e minusculas
                         c -> c.getNomeCompleto().toLowerCase().contains(busca)
                 )
         );
+    }
+
+    @Test
+    public void quandoClientePesquisarCpfEntaoExibaOClienteComEsseCpf() {
+        quandoCadastrarClienteVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso();
+
+        Cliente resultado = clienteServiceImpl.pesquisarClientePorCPF("5689778");
+
+        assertEquals("Kevelly", resultado.getNomeCompleto());
+        assertEquals("5689778", resultado.getCpf());
+        assertEquals("Rua teste", resultado.getEndereco());
     }
 }


### PR DESCRIPTION
Buscar cliente por CPF

Descrição

Como usuário do sistema,
Quero pesquisar um cliente pelo CPF,
Para que eu possa recuperar seus detalhes exclusivos.

Comando: clientes pesquisar cpf {cpf}

Critérios de aceitação:

Se o CPF existir, retornar detalhes do cliente.

Se não, mostrar uma mensagem apropriada.

Testes unitários

Testes de integração