### PR TITLE
Feature/billing 1735

### DIFF
--- a/src/main/java/org/example/controller/ContaController.java
+++ b/src/main/java/org/example/controller/ContaController.java
@@ -1,7 +1,9 @@
 package org.example.controller;
 
+import org.example.model.Conta;
 import org.example.service.ContaService;
 
+import java.util.List;
 import java.util.Scanner;
 
 public class ContaController implements Controller {
@@ -62,7 +64,12 @@ public class ContaController implements Controller {
                 return "não implementado";
 
             case "nome-titular":
-                return "não implementado";
+                if (partes.length > 3) {
+                    return pesquisarContaPorTitular(partes[3]);
+                } else {
+                    return "Informe o nome do titular da conta que deseja pesquisar. " +
+                            "Ex: contas pesquisar nome-titular Kevelly.\n";
+                }
 
             case "numero":
                 if (partes.length > 3) {
@@ -97,5 +104,20 @@ public class ContaController implements Controller {
         } catch (Exception e) {
             return e.getMessage();
         }
+    }
+
+    public String pesquisarContaPorTitular(String nomeCompleto) {
+        List<Conta> contas = contaService.buscarContasPorTitular(nomeCompleto);
+
+        if (contas.isEmpty()) {
+            return "Conta não encontrada. Cadastre-se e tente novamente.\n";
+        }
+
+        StringBuilder resultado = new StringBuilder("Contas encontradas: \n");
+        for (Conta conta : contas) {
+            resultado.append(conta.toString()).append("\n");
+        }
+
+        return resultado.toString();
     }
 }

--- a/src/main/java/org/example/controller/ContaController.java
+++ b/src/main/java/org/example/controller/ContaController.java
@@ -106,13 +106,13 @@ public class ContaController implements Controller {
         }
     }
 
-    public String pesquisarContaPorTitular(String nomeCompleto) {
-        List<Conta> contas = contaService.buscarContasPorTitular(nomeCompleto);
-
-        if (contas.isEmpty()) {
-            return "Conta não encontrada. Cadastre-se e tente novamente.\n";
+    public String pesquisarContaPorTitular(String nomeCompleto) throws Exception {
+        List<Conta> contas;
+        try {
+            contas = contaService.buscarContasPorTitular(nomeCompleto);
+        } catch (Exception e) {
+            return e.getMessage();
         }
-
         StringBuilder resultado = new StringBuilder("Contas encontradas: \n");
         for (Conta conta : contas) {
             resultado.append(conta.toString()).append("\n");

--- a/src/main/java/org/example/service/ContaService.java
+++ b/src/main/java/org/example/service/ContaService.java
@@ -1,10 +1,15 @@
 package org.example.service;
 
+import org.example.model.Cliente;
 import org.example.model.Conta;
+
+import java.util.List;
 
 public interface ContaService {
 
     Conta cadastrarConta(String cpf, String saldo) throws Exception;
 
     Conta buscarContaPorNumero(String numeroConta) throws Exception;
+
+    List<Conta> buscarContasPorTitular(String nomeCompleto);
 }

--- a/src/main/java/org/example/service/ContaService.java
+++ b/src/main/java/org/example/service/ContaService.java
@@ -11,5 +11,5 @@ public interface ContaService {
 
     Conta buscarContaPorNumero(String numeroConta) throws Exception;
 
-    List<Conta> buscarContasPorTitular(String nomeCompleto);
+    List<Conta> buscarContasPorTitular(String nomeCompleto) throws Exception;
 }

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -65,7 +65,7 @@ public class ContaServiceImpl implements ContaService {
         List<Conta> contasEncontradas = new ArrayList<>();
 
         for (Conta conta : contas.values()) {
-            if (conta.getTitular().getNomeCompleto().toLowerCase().equals(nomeCompleto)) {
+            if (conta.getTitular().getNomeCompleto().equals(nomeCompleto)) {
                 contasEncontradas.add(conta);
             }
         }

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -3,7 +3,9 @@ package org.example.service;
 import org.example.model.Cliente;
 import org.example.model.Conta;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ContaServiceImpl implements ContaService {
@@ -56,5 +58,19 @@ public class ContaServiceImpl implements ContaService {
         }
 
         return contas.get(numeroConta);
+    }
+
+    @Override
+    public List<Conta> buscarContasPorTitular(String nomeCompleto) {
+        List<Conta> contasEncontradas = new ArrayList<>();
+//        String numeroPesquisa = numeroConta.toLowerCase();
+
+        for (Conta conta : contas.values()) {
+            if (conta.getTitular().getNomeCompleto().toLowerCase().equals(nomeCompleto)) {
+                contasEncontradas.add(conta);
+            }
+        }
+
+        return contasEncontradas;
     }
 }

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -61,13 +61,16 @@ public class ContaServiceImpl implements ContaService {
     }
 
     @Override
-    public List<Conta> buscarContasPorTitular(String nomeCompleto) {
+    public List<Conta> buscarContasPorTitular(String nomeCompleto) throws Exception {
         List<Conta> contasEncontradas = new ArrayList<>();
 //        String numeroPesquisa = numeroConta.toLowerCase();
 
         for (Conta conta : contas.values()) {
             if (conta.getTitular().getNomeCompleto().toLowerCase().equals(nomeCompleto)) {
                 contasEncontradas.add(conta);
+            }
+            if (contasEncontradas.isEmpty()) {
+                throw new Exception("Conta não encontrada. Cadastre-se e tente novamente.\n");
             }
         }
 

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -63,15 +63,15 @@ public class ContaServiceImpl implements ContaService {
     @Override
     public List<Conta> buscarContasPorTitular(String nomeCompleto) throws Exception {
         List<Conta> contasEncontradas = new ArrayList<>();
-//        String numeroPesquisa = numeroConta.toLowerCase();
 
         for (Conta conta : contas.values()) {
             if (conta.getTitular().getNomeCompleto().toLowerCase().equals(nomeCompleto)) {
                 contasEncontradas.add(conta);
             }
-            if (contasEncontradas.isEmpty()) {
-                throw new Exception("Conta não encontrada. Cadastre-se e tente novamente.\n");
-            }
+        }
+
+        if (contasEncontradas.isEmpty()) {
+            throw new Exception("Conta não encontrada. Cadastre-se e tente novamente.\n");
         }
 
         return contasEncontradas;

--- a/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Scanner;
 
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -113,8 +115,31 @@ public class ContaControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhContasPesquisarNomeTitularEntaoExibaAsContasEncontradas() throws Exception {
-        var resultadoEsperado = "não implementado";
-        var resultadoReal = controller.executar("contas pesquisar nome-titular");
+        var cliente1 = new Cliente("Kevelly", "12345678900", "Rua testes, 123");
+
+        var clienteConta1 = new Conta("0", cliente1, 123.43);
+        var clienteConta2 = new Conta("1", cliente1, 5000.0);
+
+        List<Conta> listaContas = new ArrayList<>();
+        listaContas.add(clienteConta1);
+        listaContas.add(clienteConta2);
+
+        when(contaService.buscarContasPorTitular("Kevelly")).thenReturn(listaContas);
+
+        var resultadoEsperado = "Contas encontradas: \n" +
+                "Conta de número: 0\n" +
+                "Saldo: 123.43.\n" +
+                "Pertence ao titular: Kevelly.\n" +
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua testes, 123.\n" +
+                "\n" +
+                "Conta de número: 1\n" +
+                "Saldo: 5000.0.\n" +
+                "Pertence ao titular: Kevelly.\n" +
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua testes, 123.\n" +
+                "\n";
+        var resultadoReal = controller.executar("contas pesquisar nome-titular Kevelly");
         assertEquals(resultadoEsperado, resultadoReal);
     }
 

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -29,6 +29,8 @@ public class ContaServiceImplTest {
     @Mock
     private ClienteService clienteService;
 
+    private static final String NOME_CLIENTE = "Kevelly";
+
     @BeforeEach
     public void setup() {
         contaServiceImpl = new ContaServiceImpl(clienteService); // Passa o mock para a implementação
@@ -36,7 +38,7 @@ public class ContaServiceImplTest {
 
     @Test
     public void quandoComandoForCadastrarContaVerifiqueSeOCpfFoiCadastradoEntaoCadastreComSucesso() throws Exception {
-        Cliente cliente = new Cliente("Kevelly", "5689778", "Rua teste");
+        Cliente cliente = new Cliente(NOME_CLIENTE, "5689778", "Rua teste");
 
         // Após um mock ser criado, você pode configurar ações na chamada e o retorno.
         when(clienteService.buscarClientePorCPF("5689778")).thenReturn(cliente);
@@ -103,16 +105,14 @@ public class ContaServiceImplTest {
     @Test
     public void quandoContasPesquisarNomeTitularENaoEncontrarEntaoMensagemAdequada() throws Exception {
         Exception exception = assertThrows(Exception.class, () ->
-                contaServiceImpl.buscarContasPorTitular("Kevelly"));
+                contaServiceImpl.buscarContasPorTitular(NOME_CLIENTE));
         assertEquals("Conta não encontrada. Cadastre-se e tente novamente.\n", exception.getMessage());
     }
 
     @Test
     public void quandoContasPesquisarNomeTitularEEncontrarEntaoAdicioneNaLista() throws Exception {
-        var cliente = new Cliente("Kevelly", "12345678910", "Rua teste, 123");
+        var cliente = new Cliente(NOME_CLIENTE, "12345678910", "Rua teste, 123");
         var conta = new Conta("0", cliente, 123.43);
-
-        String NOME_CLIENTE = "Kevelly";
 
         List<Conta> contas = new ArrayList<>();
         contas.add(conta);

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -112,16 +112,18 @@ public class ContaServiceImplTest {
         var cliente = new Cliente("Kevelly", "12345678910", "Rua teste, 123");
         var conta = new Conta("0", cliente, 123.43);
 
+        String busca = "Kevelly";
+
         List<Conta> contas = new ArrayList<>();
         contas.add(conta);
 
         // Mocka o comportamento
-        when(contaService.buscarContasPorTitular("Kevelly")).thenReturn(contas);
+        when(contaService.buscarContasPorTitular(busca)).thenReturn(contas);
 
         // Chama o metodo mockado
-        List<Conta> resultado = contaService.buscarContasPorTitular("Kevelly");
+        List<Conta> resultado = contaService.buscarContasPorTitular(busca);
 
         assertEquals(1, resultado.size());
-        assertEquals("Kevelly", resultado.get(0).getTitular().getNomeCompleto());
+        assertEquals(busca, resultado.get(0).getTitular().getNomeCompleto());
     }
 }

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -30,6 +30,10 @@ public class ContaServiceImplTest {
     private ClienteService clienteService;
 
     private static final String NOME_CLIENTE = "Kevelly";
+    private static final String CPF_CLIENTE = "12345678900";
+    private static final String ENDERECO_CLIENTE = "Rua dos testes, 56";
+    private static final Double SALDO_CONTA = 123.43;
+    private static final String NUMERO_CONTA = "0";
 
     @BeforeEach
     public void setup() {
@@ -38,15 +42,15 @@ public class ContaServiceImplTest {
 
     @Test
     public void quandoComandoForCadastrarContaVerifiqueSeOCpfFoiCadastradoEntaoCadastreComSucesso() throws Exception {
-        Cliente cliente = new Cliente(NOME_CLIENTE, "5689778", "Rua teste");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
         // Após um mock ser criado, você pode configurar ações na chamada e o retorno.
-        when(clienteService.buscarClientePorCPF("5689778")).thenReturn(cliente);
+        when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
-        Conta resultadoReal = contaServiceImpl.cadastrarConta("5689778", String.valueOf(123.34));
+        Conta resultadoReal = contaServiceImpl.cadastrarConta(CPF_CLIENTE, String.valueOf(SALDO_CONTA));
 
-        assertEquals("5689778", resultadoReal.getTitular().getCpf());
-        assertEquals(123.34, resultadoReal.getSaldo());
+        assertEquals(CPF_CLIENTE, resultadoReal.getTitular().getCpf());
+        assertEquals(SALDO_CONTA, resultadoReal.getSaldo());
     }
 
     @ParameterizedTest
@@ -54,7 +58,7 @@ public class ContaServiceImplTest {
     public void quandoContasCadastrarECpfForVazioOuNuloEntaoExibaMensagem(String numeroConta) throws Exception {
 
         Exception exception = assertThrows(Exception.class, () ->
-                contaServiceImpl.cadastrarConta(numeroConta, String.valueOf(234.243))
+                contaServiceImpl.cadastrarConta(numeroConta, String.valueOf(SALDO_CONTA))
         );
         assertEquals("O CPF não pode ser nulo ou vazio.\n", exception.getMessage());
     }
@@ -65,7 +69,7 @@ public class ContaServiceImplTest {
             (String saldoStr) throws Exception {
 
         Exception exception = assertThrows(Exception.class, () ->
-                contaServiceImpl.cadastrarConta("12345678900", saldoStr)
+                contaServiceImpl.cadastrarConta(CPF_CLIENTE, saldoStr)
         );
         assertEquals("O saldo não pode ser nulo ou vazio.\n", exception.getMessage());
     }
@@ -75,7 +79,7 @@ public class ContaServiceImplTest {
     public void quandoContasCadastrarESaldoForValorInvalidoEntaoExibaMensagem(String saldoStr) throws Exception {
 
         Exception exception = assertThrows(Exception.class, () -> {
-            contaServiceImpl.cadastrarConta("12345678900", saldoStr);
+            contaServiceImpl.cadastrarConta(CPF_CLIENTE, saldoStr);
 
         });
         assertEquals("O saldo deve ser um número válido.\n", exception.getMessage());
@@ -86,7 +90,7 @@ public class ContaServiceImplTest {
     public void quandoContasCadastrarESaldoForVazioOuNuloEntaoExibaMensagem(Double saldo) throws Exception {
 
         Exception exception = assertThrows(Exception.class, () -> {
-            contaServiceImpl.cadastrarConta("12345678900", String.valueOf(saldo));
+            contaServiceImpl.cadastrarConta(CPF_CLIENTE, String.valueOf(saldo));
 
         });
         assertEquals("O saldo deve ser um número maior que zero.\n", exception.getMessage());
@@ -111,8 +115,8 @@ public class ContaServiceImplTest {
 
     @Test
     public void quandoContasPesquisarNomeTitularEEncontrarEntaoAdicioneNaLista() throws Exception {
-        var cliente = new Cliente(NOME_CLIENTE, "12345678910", "Rua teste, 123");
-        var conta = new Conta("0", cliente, 123.43);
+        var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA);
 
         List<Conta> contas = new ArrayList<>();
         contas.add(conta);

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +21,9 @@ import static org.mockito.Mockito.when;
 public class ContaServiceImplTest {
 
     private ContaServiceImpl contaServiceImpl;
+
+    @Mock
+    private ContaService contaService;
 
     // cria uma instância de uma classe, porém Mockada
     @Mock
@@ -87,11 +93,35 @@ public class ContaServiceImplTest {
     @ParameterizedTest
     @NullAndEmptySource //quando a função for executada passa null e depois vazia
     public void quandoContasPesquisarNumeroContaForVazioOuNuloEntaoExibaMensagem(String numeroConta) throws Exception {
-
         Exception exception = assertThrows(Exception.class, () ->
                 contaServiceImpl.buscarContaPorNumero(numeroConta)
         );
         assertEquals("A conta informada não foi encontrada. Cadastre-se e tente novamente.\n",
                 exception.getMessage());
+    }
+
+    @Test
+    public void quandoContasPesquisarNomeTitularENaoEncontrarEntaoMensagemAdequada() throws Exception {
+        Exception exception = assertThrows(Exception.class, () ->
+                contaServiceImpl.buscarContasPorTitular("Kevelly"));
+        assertEquals("Conta não encontrada. Cadastre-se e tente novamente.\n", exception.getMessage());
+    }
+
+    @Test
+    public void quandoContasPesquisarNomeTitularEEncontrarEntaoAdicioneNaLista() throws Exception {
+        var cliente = new Cliente("Kevelly", "12345678910", "Rua teste, 123");
+        var conta = new Conta("0", cliente, 123.43);
+
+        List<Conta> contas = new ArrayList<>();
+        contas.add(conta);
+
+        // Mocka o comportamento
+        when(contaService.buscarContasPorTitular("Kevelly")).thenReturn(contas);
+
+        // Chama o metodo mockado
+        List<Conta> resultado = contaService.buscarContasPorTitular("Kevelly");
+
+        assertEquals(1, resultado.size());
+        assertEquals("Kevelly", resultado.get(0).getTitular().getNomeCompleto());
     }
 }

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -112,18 +112,18 @@ public class ContaServiceImplTest {
         var cliente = new Cliente("Kevelly", "12345678910", "Rua teste, 123");
         var conta = new Conta("0", cliente, 123.43);
 
-        String busca = "Kevelly";
+        String NOME_CLIENTE = "Kevelly";
 
         List<Conta> contas = new ArrayList<>();
         contas.add(conta);
 
         // Mocka o comportamento
-        when(contaService.buscarContasPorTitular(busca)).thenReturn(contas);
+        when(contaService.buscarContasPorTitular(NOME_CLIENTE)).thenReturn(contas);
 
         // Chama o metodo mockado
-        List<Conta> resultado = contaService.buscarContasPorTitular(busca);
+        List<Conta> resultado = contaService.buscarContasPorTitular(NOME_CLIENTE);
 
         assertEquals(1, resultado.size());
-        assertEquals(busca, resultado.get(0).getTitular().getNomeCompleto());
+        assertEquals(NOME_CLIENTE, resultado.get(0).getTitular().getNomeCompleto());
     }
 }


### PR DESCRIPTION
Procurar contas pelo nome do titular

Descrição

Como um usuário do sistema,
Quero buscar contas a partir do nome do titular
Para que eu possa acessar suas informações financeiras.

Comando: contas pesquisar nome-titular {nome do cliente}

Critérios de aceitação:

Mostre uma lista com as contas encontradas

Se nenhuma conta for encontrada, mostre uma mensagem apropriada.

Testes de unidade

Testes de integração