### PR TITLE
Feature/billing 1736

### DIFF
--- a/src/main/java/org/example/controller/ContaController.java
+++ b/src/main/java/org/example/controller/ContaController.java
@@ -103,7 +103,7 @@ public class ContaController implements Controller {
         }
     }
 
-    public String pesquisarContaPorNumero(String numeroConta) throws Exception {
+    public String pesquisarContaPorNumero(String numeroConta) {
         try {
             return "Conta encontrada: \n" + contaService.buscarContaPorNumero(numeroConta).toString();
         } catch (Exception e) {
@@ -111,7 +111,7 @@ public class ContaController implements Controller {
         }
     }
 
-    public String pesquisarContaPorTitular(String nomeCompleto) throws Exception {
+    public String pesquisarContaPorTitular(String nomeCompleto) {
         List<Conta> contas;
         try {
             contas = contaService.buscarContasPorTitular(nomeCompleto);
@@ -127,7 +127,7 @@ public class ContaController implements Controller {
     }
 
 
-    public String pesquisarContaPorCPF(String cpf) throws Exception {
+    public String pesquisarContaPorCPF(String cpf) {
         List<Conta> contas;
         try {
             contas = contaService.buscarContasPorCPF(cpf);

--- a/src/main/java/org/example/controller/ContaController.java
+++ b/src/main/java/org/example/controller/ContaController.java
@@ -61,7 +61,12 @@ public class ContaController implements Controller {
 
         switch (partes[2]) {
             case "cpf-titular":
-                return "não implementado";
+                if (partes.length > 3) {
+                    return pesquisarContaPorCPF(partes[3]);
+                } else {
+                    return "Informe o CPF do titular da conta que deseja pesquisar. " +
+                            "Ex: contas pesquisar cpf-titular 12345678900.\n";
+                }
 
             case "nome-titular":
                 if (partes.length > 3) {
@@ -110,6 +115,22 @@ public class ContaController implements Controller {
         List<Conta> contas;
         try {
             contas = contaService.buscarContasPorTitular(nomeCompleto);
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+        StringBuilder resultado = new StringBuilder("Contas encontradas: \n");
+        for (Conta conta : contas) {
+            resultado.append(conta.toString()).append("\n");
+        }
+
+        return resultado.toString();
+    }
+
+
+    public String pesquisarContaPorCPF(String cpf) throws Exception {
+        List<Conta> contas;
+        try {
+            contas = contaService.buscarContasPorCPF(cpf);
         } catch (Exception e) {
             return e.getMessage();
         }

--- a/src/main/java/org/example/service/ContaService.java
+++ b/src/main/java/org/example/service/ContaService.java
@@ -12,4 +12,6 @@ public interface ContaService {
     Conta buscarContaPorNumero(String numeroConta) throws Exception;
 
     List<Conta> buscarContasPorTitular(String nomeCompleto) throws Exception;
+
+    List<Conta> buscarContasPorCPF(String cpf) throws Exception;
 }

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -76,4 +76,21 @@ public class ContaServiceImpl implements ContaService {
 
         return contasEncontradas;
     }
+
+    @Override
+    public List<Conta> buscarContasPorCPF(String cpf) throws Exception {
+        List<Conta> contasEncontradas = new ArrayList<>();
+
+        for (Conta conta : contas.values()) {
+            if (conta.getTitular().getCpf().equals(cpf)) {
+                contasEncontradas.add(conta);
+            }
+        }
+
+        if (contasEncontradas.isEmpty()) {
+            throw new Exception("Conta não encontrada. Cadastre-se e tente novamente.\n");
+        }
+
+        return contasEncontradas;
+    }
 }

--- a/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
@@ -35,6 +35,12 @@ public class ContaControllerIntegrationTest {
     @Mock
     private ClienteService clienteService; // Mock do ClienteService
 
+    private static final String NOME_CLIENTE = "Kevelly";
+    private static final String CPF_CLIENTE = "12345678900";
+    private static final String ENDERECO_CLIENTE = "Rua dos testes, 56";
+    private static final Double SALDO_CONTA = 123.43;
+    private static final String NUMERO_CONTA = "0";
+
     @BeforeEach
     public void setup() {
 //        contaService = new ContaServiceImpl(clienteService); // Passa o mock para a implementação
@@ -62,19 +68,19 @@ public class ContaControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhContasCadastrarEntaoCadastreAsContas() throws Exception {
-        var cliente = new Cliente("Kevelly", "0123456789", "Rua teste, 123");
+        var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
-        var conta = new Conta("0", cliente, 123.43);
-        when(contaService.cadastrarConta("0123456789", String.valueOf(123.43))).thenReturn(conta);
+        var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA);
+        when(contaService.cadastrarConta(CPF_CLIENTE, String.valueOf(SALDO_CONTA))).thenReturn(conta);
 
         var resultadoEsperado = "Conta cadastrada com sucesso!\n" +
                 "Conta de número: 0\n" +
                 "Saldo: 123.43.\n" +
                 "Pertence ao titular: Kevelly.\n" +
-                "CPF: 0123456789.\n" +
-                "Endereço: Rua teste, 123.\n";
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua dos testes, 56.\n";
 
-        this.inputStream.setInputs("0123456789\n123.43\n");
+        this.inputStream.setInputs("12345678900\n123.43\n");
         var resultadoReal = controller.executar("contas cadastrar");
 
         assertEquals(resultadoEsperado, resultadoReal);
@@ -108,36 +114,59 @@ public class ContaControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhContasPesquisarCpfTitularEntaoExibaAsContasEncontradas() throws Exception {
-        var resultadoEsperado = "não implementado";
-        var resultadoReal = controller.executar("contas pesquisar cpf-titular");
-        assertEquals(resultadoEsperado, resultadoReal);
-    }
+        var cliente1 = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
-    @Test
-    public void quandoComandoEhContasPesquisarNomeTitularEntaoExibaAsContasEncontradas() throws Exception {
-        var cliente1 = new Cliente("Kevelly", "12345678900", "Rua testes, 123");
-
-        var clienteConta1 = new Conta("0", cliente1, 123.43);
+        var clienteConta1 = new Conta(NUMERO_CONTA, cliente1, SALDO_CONTA);
         var clienteConta2 = new Conta("1", cliente1, 5000.0);
 
         List<Conta> listaContas = new ArrayList<>();
         listaContas.add(clienteConta1);
         listaContas.add(clienteConta2);
 
-        when(contaService.buscarContasPorTitular("Kevelly")).thenReturn(listaContas);
+        when(contaService.buscarContasPorCPF(CPF_CLIENTE)).thenReturn(listaContas);
 
         var resultadoEsperado = "Contas encontradas: \n" +
                 "Conta de número: 0\n" +
                 "Saldo: 123.43.\n" +
                 "Pertence ao titular: Kevelly.\n" +
                 "CPF: 12345678900.\n" +
-                "Endereço: Rua testes, 123.\n" +
+                "Endereço: Rua dos testes, 56.\n" +
                 "\n" +
                 "Conta de número: 1\n" +
                 "Saldo: 5000.0.\n" +
                 "Pertence ao titular: Kevelly.\n" +
                 "CPF: 12345678900.\n" +
-                "Endereço: Rua testes, 123.\n" +
+                "Endereço: Rua dos testes, 56.\n" +
+                "\n";
+        var resultadoReal = controller.executar("contas pesquisar cpf-titular 12345678900");
+        assertEquals(resultadoEsperado, resultadoReal);
+    }
+
+    @Test
+    public void quandoComandoEhContasPesquisarNomeTitularEntaoExibaAsContasEncontradas() throws Exception {
+        var cliente1 = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+
+        var clienteConta1 = new Conta(NUMERO_CONTA, cliente1, SALDO_CONTA);
+        var clienteConta2 = new Conta("1", cliente1, 5000.0);
+
+        List<Conta> listaContas = new ArrayList<>();
+        listaContas.add(clienteConta1);
+        listaContas.add(clienteConta2);
+
+        when(contaService.buscarContasPorTitular(NOME_CLIENTE)).thenReturn(listaContas);
+
+        var resultadoEsperado = "Contas encontradas: \n" +
+                "Conta de número: 0\n" +
+                "Saldo: 123.43.\n" +
+                "Pertence ao titular: Kevelly.\n" +
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua dos testes, 56.\n" +
+                "\n" +
+                "Conta de número: 1\n" +
+                "Saldo: 5000.0.\n" +
+                "Pertence ao titular: Kevelly.\n" +
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua dos testes, 56.\n" +
                 "\n";
         var resultadoReal = controller.executar("contas pesquisar nome-titular Kevelly");
         assertEquals(resultadoEsperado, resultadoReal);
@@ -145,17 +174,17 @@ public class ContaControllerIntegrationTest {
 
     @Test
     public void quandoComandoEhContasPesquisarNumeroEntaoExibaDetalhesDaConta() throws Exception {
-        var cliente = new Cliente("Kevelly", "12345678910", "Rua teste, 123");
+        var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
-        var conta = new Conta("0", cliente, 123.43);
-        when(contaService.buscarContaPorNumero("0")).thenReturn(conta);
+        var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA);
+        when(contaService.buscarContaPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         var resultadoEsperado = "Conta encontrada: \n" +
                 "Conta de número: 0\n" +
                 "Saldo: 123.43.\n" +
                 "Pertence ao titular: Kevelly.\n" +
-                "CPF: 12345678910.\n" +
-                "Endereço: Rua teste, 123.\n";
+                "CPF: 12345678900.\n" +
+                "Endereço: Rua dos testes, 56.\n";
         var resultadoReal = controller.executar("contas pesquisar numero 0");
 
         assertEquals(resultadoEsperado, resultadoReal);

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -130,4 +130,27 @@ public class ContaServiceImplTest {
         assertEquals(1, resultado.size());
         assertEquals(NOME_CLIENTE, resultado.get(0).getTitular().getNomeCompleto());
     }
+
+    @Test
+    public void quandoContasPesquisarCPFTitularENaoEncontrarEntaoMensagemAdequada() {
+        Exception exception = assertThrows(Exception.class, () ->
+                contaServiceImpl.buscarContasPorCPF(CPF_CLIENTE));
+        assertEquals("Conta não encontrada. Cadastre-se e tente novamente.\n", exception.getMessage());
+    }
+
+    @Test
+    public void quandoContasPesquisarCPFTitularEEncontrarEntaoAdicioneNaLista() throws Exception {
+        var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA);
+
+        List<Conta> contas = new ArrayList<>();
+        contas.add(conta);
+
+        when(contaService.buscarContasPorCPF(CPF_CLIENTE)).thenReturn(contas);
+
+        List<Conta> resultado = contaService.buscarContasPorCPF(CPF_CLIENTE);
+
+        assertEquals(1, resultado.size());
+        assertEquals(CPF_CLIENTE, resultado.get(0).getTitular().getCpf());
+    }
 }


### PR DESCRIPTION
Procurar contas pelo CPF do titular

Descrição

Como usuário do sistema,
Quero procurar contas pelo CPF do titular
Para que eu possa acessar suas informações financeiras.

Comando: contas pesquisar cpf-titular {cpf do cliente}

Critérios de aceitação:

Mostre uma lista com as contas encontradas

Se nenhuma conta for encontrada, mostre uma mensagem apropriada.

Testes unitários

Testes de integração