### PR TITLE
Feature/billing 1796

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -8,10 +8,10 @@ import org.example.controller.ClienteController;
 import org.example.controller.ContaController;
 import org.example.controller.FaturaController;
 import org.example.controller.FrontController;
-import org.example.model.Cartao;
-import org.example.model.Conta;
 import org.example.repository.CartaoRepository;
+import org.example.repository.ContaRepository;
 import org.example.repository.InMemoryCartaoRepository;
+import org.example.repository.InMemoryContaRepository;
 import org.example.service.ClienteService;
 import org.example.service.ClienteServiceImpl;
 import org.example.service.ContaService;
@@ -25,13 +25,12 @@ public class Main {
 
         System.out.println("----------- Seja bem-vindo! -----------");
 
-        HashMap<String, Conta> contaRepository = new HashMap<>();
-
         CartaoRepository cartaoRepository = new InMemoryCartaoRepository();
+        ContaRepository contaRepository = new InMemoryContaRepository();
 
         //inicializa a ClienteService | dependencia criada fora da controller
         ClienteService clienteService = new ClienteServiceImpl();
-        ContaService contaService = new ContaServiceImpl(clienteService, contaRepository);
+        ContaService contaService = new ContaServiceImpl(contaRepository, clienteService);
         CartaoService cartaoService = new CartaoServiceImpl(cartaoRepository, clienteService, contaService);
 
         var cartoesController = new CartaoController(cartaoService, scanner);

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -25,15 +25,14 @@ public class Main {
 
         System.out.println("----------- Seja bem-vindo! -----------");
 
-        HashMap<String, Cartao> cartaoHashMap = new HashMap<>();
         HashMap<String, Conta> contaRepository = new HashMap<>();
 
-        CartaoRepository cartaoRepository = new InMemoryCartaoRepository(cartaoHashMap);
+        CartaoRepository cartaoRepository = new InMemoryCartaoRepository();
 
         //inicializa a ClienteService | dependencia criada fora da controller
         ClienteService clienteService = new ClienteServiceImpl();
         ContaService contaService = new ContaServiceImpl(clienteService, contaRepository);
-        CartaoService cartaoService = new CartaoServiceImpl(clienteService, contaService, cartaoRepository);
+        CartaoService cartaoService = new CartaoServiceImpl(cartaoRepository, clienteService, contaService);
 
         var cartoesController = new CartaoController(cartaoService, scanner);
         //Injeção de dependência -> passar a dependencia (ClienteService) ao invés de criar dentro do ClientesController

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -10,8 +10,10 @@ import org.example.controller.FaturaController;
 import org.example.controller.FrontController;
 import org.example.repository.CartaoRepository;
 import org.example.repository.ContaRepository;
+import org.example.repository.ClienteRepository;
 import org.example.repository.InMemoryCartaoRepository;
 import org.example.repository.InMemoryContaRepository;
+import org.example.repository.InMemoryClienteRepository;
 import org.example.service.ClienteService;
 import org.example.service.ClienteServiceImpl;
 import org.example.service.ContaService;
@@ -25,11 +27,12 @@ public class Main {
 
         System.out.println("----------- Seja bem-vindo! -----------");
 
+        ClienteRepository clienteRepository = new InMemoryClienteRepository();
         CartaoRepository cartaoRepository = new InMemoryCartaoRepository();
         ContaRepository contaRepository = new InMemoryContaRepository();
 
         //inicializa a ClienteService | dependencia criada fora da controller
-        ClienteService clienteService = new ClienteServiceImpl();
+        ClienteService clienteService = new ClienteServiceImpl(clienteRepository);
         ContaService contaService = new ContaServiceImpl(contaRepository, clienteService);
         CartaoService cartaoService = new CartaoServiceImpl(cartaoRepository, clienteService, contaService);
 

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -2,6 +2,7 @@ package org.example;
 
 import java.util.HashMap;
 import java.util.Scanner;
+
 import org.example.controller.CartaoController;
 import org.example.controller.ClienteController;
 import org.example.controller.ContaController;
@@ -9,6 +10,8 @@ import org.example.controller.FaturaController;
 import org.example.controller.FrontController;
 import org.example.model.Cartao;
 import org.example.model.Conta;
+import org.example.repository.CartaoRepository;
+import org.example.repository.InMemoryCartaoRepository;
 import org.example.service.ClienteService;
 import org.example.service.ClienteServiceImpl;
 import org.example.service.ContaService;
@@ -22,17 +25,15 @@ public class Main {
 
         System.out.println("----------- Seja bem-vindo! -----------");
 
-        ClienteService clienteService;
-        ContaService contaService;
-        CartaoService cartaoService;
-
-        HashMap<String, Cartao> cartaoRepository = new HashMap<>();
+        HashMap<String, Cartao> cartaoHashMap = new HashMap<>();
         HashMap<String, Conta> contaRepository = new HashMap<>();
 
+        CartaoRepository cartaoRepository = new InMemoryCartaoRepository(cartaoHashMap);
+
         //inicializa a ClienteService | dependencia criada fora da controller
-        clienteService = new ClienteServiceImpl();
-        contaService = new ContaServiceImpl(clienteService, contaRepository);
-        cartaoService = new CartaoServiceImpl(clienteService, contaService, cartaoRepository);
+        ClienteService clienteService = new ClienteServiceImpl();
+        ContaService contaService = new ContaServiceImpl(clienteService, contaRepository);
+        CartaoService cartaoService = new CartaoServiceImpl(clienteService, contaService, cartaoRepository);
 
         var cartoesController = new CartaoController(cartaoService, scanner);
         //Injeção de dependência -> passar a dependencia (ClienteService) ao invés de criar dentro do ClientesController

--- a/src/main/java/org/example/repository/CartaoRepository.java
+++ b/src/main/java/org/example/repository/CartaoRepository.java
@@ -6,6 +6,4 @@ public interface CartaoRepository {
     Cartao cadastrar(Cartao cartao);
 
     Cartao buscarPorNumero(String numeroCartao);
-
-    Cartao editar(Cartao cartao);
 }

--- a/src/main/java/org/example/repository/CartaoRepository.java
+++ b/src/main/java/org/example/repository/CartaoRepository.java
@@ -1,0 +1,13 @@
+package org.example.repository;
+
+import org.example.model.Cartao;
+
+public interface CartaoRepository {
+    Cartao cadastrar(Cartao cartao);
+
+    Cartao buscarPorNumero(String numeroCartao);
+
+    boolean buscarSeExiste(String numeroCartao);
+
+    Cartao editar(Cartao cartao);
+}

--- a/src/main/java/org/example/repository/CartaoRepository.java
+++ b/src/main/java/org/example/repository/CartaoRepository.java
@@ -7,7 +7,5 @@ public interface CartaoRepository {
 
     Cartao buscarPorNumero(String numeroCartao);
 
-    boolean buscarSeExiste(String numeroCartao);
-
     Cartao editar(Cartao cartao);
 }

--- a/src/main/java/org/example/repository/ClienteRepository.java
+++ b/src/main/java/org/example/repository/ClienteRepository.java
@@ -1,0 +1,13 @@
+package org.example.repository;
+
+import org.example.model.Cliente;
+
+import java.util.Collection;
+
+public interface ClienteRepository {
+    Cliente cadastrar(Cliente cliente);
+
+    Cliente buscarPorCPF(String cpf);
+
+    Collection<Cliente> buscarValores(String nome);
+}

--- a/src/main/java/org/example/repository/ContaRepository.java
+++ b/src/main/java/org/example/repository/ContaRepository.java
@@ -1,0 +1,16 @@
+package org.example.repository;
+
+import org.example.model.Conta;
+
+import java.util.Collection;
+
+public interface ContaRepository {
+    Conta cadastrar(Conta conta);
+
+    // Colletion -> armazena um grupo de objetos. Mais genérico e flexível
+    Collection<Conta> buscarValores(String cpf);
+
+    Conta buscarPorNumero(String numeroConta);
+
+    int buscarTamanho();
+}

--- a/src/main/java/org/example/repository/InMemoryCartaoRepository.java
+++ b/src/main/java/org/example/repository/InMemoryCartaoRepository.java
@@ -2,14 +2,11 @@ package org.example.repository;
 
 import org.example.model.Cartao;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class InMemoryCartaoRepository implements CartaoRepository {
-    private final Map<String, Cartao> cartaoRepository;
-
-    public InMemoryCartaoRepository(Map<String, Cartao> cartaoRepository) {
-        this.cartaoRepository = cartaoRepository;
-    }
+    private final Map<String, Cartao> cartaoRepository = new HashMap<>();
 
     @Override
     public Cartao cadastrar(Cartao cartao) {

--- a/src/main/java/org/example/repository/InMemoryCartaoRepository.java
+++ b/src/main/java/org/example/repository/InMemoryCartaoRepository.java
@@ -21,11 +21,8 @@ public class InMemoryCartaoRepository implements CartaoRepository {
 
     @Override
     public Cartao editar(Cartao cartao) {
-        var numero = cartaoRepository.get(cartao.getNumeroCartao());
+        cartaoRepository.put(cartao.getNumeroCartao(), cartao);
 
-        // Sugestão para simplificar o if
-        numero.setBloqueado(!numero.isBloqueado());
-
-        return numero;
+        return cartao;
     }
 }

--- a/src/main/java/org/example/repository/InMemoryCartaoRepository.java
+++ b/src/main/java/org/example/repository/InMemoryCartaoRepository.java
@@ -1,0 +1,39 @@
+package org.example.repository;
+
+import org.example.model.Cartao;
+
+import java.util.Map;
+
+public class InMemoryCartaoRepository implements CartaoRepository {
+    private final Map<String, Cartao> cartaoRepository;
+
+    public InMemoryCartaoRepository(Map<String, Cartao> cartaoRepository) {
+        this.cartaoRepository = cartaoRepository;
+    }
+
+    @Override
+    public Cartao cadastrar(Cartao cartao) {
+        cartaoRepository.put(cartao.getNumeroCartao(), cartao);
+        return cartao;
+    }
+
+    @Override
+    public Cartao buscarPorNumero(String numeroCartao) {
+        return cartaoRepository.get(numeroCartao);
+    }
+
+    @Override
+    public boolean buscarSeExiste(String numeroCartao) {
+        return cartaoRepository.containsKey(numeroCartao);
+    }
+
+    @Override
+    public Cartao editar(Cartao cartao) {
+        var numero = cartaoRepository.get(cartao.getNumeroCartao());
+
+        // Sugestão para simplificar o if
+        numero.setBloqueado(!numero.isBloqueado());
+
+        return numero;
+    }
+}

--- a/src/main/java/org/example/repository/InMemoryCartaoRepository.java
+++ b/src/main/java/org/example/repository/InMemoryCartaoRepository.java
@@ -23,11 +23,6 @@ public class InMemoryCartaoRepository implements CartaoRepository {
     }
 
     @Override
-    public boolean buscarSeExiste(String numeroCartao) {
-        return cartaoRepository.containsKey(numeroCartao);
-    }
-
-    @Override
     public Cartao editar(Cartao cartao) {
         var numero = cartaoRepository.get(cartao.getNumeroCartao());
 

--- a/src/main/java/org/example/repository/InMemoryCartaoRepository.java
+++ b/src/main/java/org/example/repository/InMemoryCartaoRepository.java
@@ -18,11 +18,4 @@ public class InMemoryCartaoRepository implements CartaoRepository {
     public Cartao buscarPorNumero(String numeroCartao) {
         return cartaoRepository.get(numeroCartao);
     }
-
-    @Override
-    public Cartao editar(Cartao cartao) {
-        cartaoRepository.put(cartao.getNumeroCartao(), cartao);
-
-        return cartao;
-    }
 }

--- a/src/main/java/org/example/repository/InMemoryClienteRepository.java
+++ b/src/main/java/org/example/repository/InMemoryClienteRepository.java
@@ -1,0 +1,26 @@
+package org.example.repository;
+
+import org.example.model.Cliente;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryClienteRepository implements ClienteRepository {
+    private final Map<String, Cliente> clienteRepository = new HashMap<>();
+
+    @Override
+    public Cliente cadastrar(Cliente cliente) {
+        return clienteRepository.put(cliente.getCpf(), cliente);
+    }
+
+    @Override
+    public Cliente buscarPorCPF(String cpf) {
+        return clienteRepository.get(cpf);
+    }
+
+    @Override
+    public Collection<Cliente> buscarValores(String nome) {
+        return clienteRepository.values();
+    }
+}

--- a/src/main/java/org/example/repository/InMemoryContaRepository.java
+++ b/src/main/java/org/example/repository/InMemoryContaRepository.java
@@ -1,0 +1,31 @@
+package org.example.repository;
+
+import org.example.model.Conta;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+public class InMemoryContaRepository implements ContaRepository {
+    private final HashMap<String, Conta> contaRepository = new HashMap<>();
+
+    @Override
+    public Conta cadastrar(Conta conta) {
+        contaRepository.put(conta.getNumeroConta(), conta);
+        return conta;
+    }
+
+    @Override
+    public Collection<Conta> buscarValores(String cpf) {
+        return contaRepository.values();
+    }
+
+    @Override
+    public Conta buscarPorNumero(String numeroConta) {
+        return contaRepository.get(numeroConta);
+    }
+
+    @Override
+    public int buscarTamanho() {
+        return contaRepository.size();
+    }
+}

--- a/src/main/java/org/example/service/CartaoServiceImpl.java
+++ b/src/main/java/org/example/service/CartaoServiceImpl.java
@@ -93,7 +93,7 @@ public class CartaoServiceImpl implements CartaoService {
         }
 
         cartao.setBloqueado(true);
-        cartaoRepository.editar(cartao);
+        cartaoRepository.cadastrar(cartao);
         return cartao;
     }
 
@@ -112,7 +112,7 @@ public class CartaoServiceImpl implements CartaoService {
         }
 
         cartao.setBloqueado(false);
-        cartaoRepository.editar(cartao);
+        cartaoRepository.cadastrar(cartao);
         return cartao;
     }
 }

--- a/src/main/java/org/example/service/CartaoServiceImpl.java
+++ b/src/main/java/org/example/service/CartaoServiceImpl.java
@@ -3,23 +3,23 @@ package org.example.service;
 import org.example.model.Cartao;
 import org.example.model.Cliente;
 import org.example.model.Conta;
+import org.example.repository.CartaoRepository;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.Random;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 
 public class CartaoServiceImpl implements CartaoService {
-    private final Map<String, Cartao> cartaoRepository;
+    private final CartaoRepository cartaoRepository;
 
     private final ClienteService clienteService;
 
     private final ContaService contaService;
 
-    public CartaoServiceImpl(ClienteService clienteService, ContaService contaService, Map<String, Cartao> cartaoRepository) {
+    public CartaoServiceImpl(ClienteService clienteService, ContaService contaService, CartaoRepository cartaoRepository) {
         this.clienteService = clienteService;
         this.contaService = contaService;
         this.cartaoRepository = cartaoRepository;
@@ -64,17 +64,17 @@ public class CartaoServiceImpl implements CartaoService {
 
         do {
             numeroCartao = valueOf(random.nextInt(MAX - MIN + 1) + MIN);
-        } while (cartaoRepository.containsKey(numeroCartao));
+        } while (cartaoRepository.buscarSeExiste(numeroCartao));
 
         Cartao cartao = new Cartao(numeroCartao, cvv, dtVencimento, cliente, conta, false);
-        cartaoRepository.put(numeroCartao, cartao);
+        cartaoRepository.cadastrar(cartao);
 
         return cartao;
     }
 
     @Override
     public Cartao buscarCartaoPorNumero(String numeroCartao) throws Exception {
-        Cartao cartao = cartaoRepository.get(numeroCartao);
+        Cartao cartao = cartaoRepository.buscarPorNumero(numeroCartao);
         if (numeroCartao == null || numeroCartao.trim().isEmpty() || cartao == null) {
             throw new Exception("O cartão informado não foi encontrado. Cadastre-o e tente novamente.\n");
         }
@@ -87,10 +87,10 @@ public class CartaoServiceImpl implements CartaoService {
         Cartao cartao = buscarCartaoPorNumero(numeroCartao);
 
         if (cartao.isBloqueado()) {
-            throw new Exception("Esse cartão está bloqueado.\n");
+            throw new Exception("Esse cartão já está bloqueado.\n");
         }
 
-        cartao.setBloqueado(true);
+        cartaoRepository.editar(cartao);
         return cartao;
     }
 
@@ -105,10 +105,10 @@ public class CartaoServiceImpl implements CartaoService {
         contaService.buscarContaPorNumero(numeroConta);
 
         if (!cartao.isBloqueado()) {
-            throw new Exception("Esse cartão está desbloqueado.\n");
+            throw new Exception("Esse cartão já está desbloqueado.\n");
         }
 
-        cartao.setBloqueado(false);
+        cartaoRepository.editar(cartao);
         return cartao;
     }
 }

--- a/src/main/java/org/example/service/CartaoServiceImpl.java
+++ b/src/main/java/org/example/service/CartaoServiceImpl.java
@@ -19,10 +19,12 @@ public class CartaoServiceImpl implements CartaoService {
 
     private final ContaService contaService;
 
-    public CartaoServiceImpl(ClienteService clienteService, ContaService contaService, CartaoRepository cartaoRepository) {
+    public CartaoServiceImpl(CartaoRepository cartaoRepository,
+                             ClienteService clienteService,
+                             ContaService contaService) {
+        this.cartaoRepository = cartaoRepository;
         this.clienteService = clienteService;
         this.contaService = contaService;
-        this.cartaoRepository = cartaoRepository;
     }
 
     @Override
@@ -64,7 +66,7 @@ public class CartaoServiceImpl implements CartaoService {
 
         do {
             numeroCartao = valueOf(random.nextInt(MAX - MIN + 1) + MIN);
-        } while (cartaoRepository.buscarSeExiste(numeroCartao));
+        } while (cartaoRepository.buscarPorNumero(numeroCartao) != null);
 
         Cartao cartao = new Cartao(numeroCartao, cvv, dtVencimento, cliente, conta, false);
         cartaoRepository.cadastrar(cartao);

--- a/src/main/java/org/example/service/CartaoServiceImpl.java
+++ b/src/main/java/org/example/service/CartaoServiceImpl.java
@@ -92,6 +92,7 @@ public class CartaoServiceImpl implements CartaoService {
             throw new Exception("Esse cartão já está bloqueado.\n");
         }
 
+        cartao.setBloqueado(true);
         cartaoRepository.editar(cartao);
         return cartao;
     }
@@ -110,6 +111,7 @@ public class CartaoServiceImpl implements CartaoService {
             throw new Exception("Esse cartão já está desbloqueado.\n");
         }
 
+        cartao.setBloqueado(false);
         cartaoRepository.editar(cartao);
         return cartao;
     }

--- a/src/main/java/org/example/service/ClienteServiceImpl.java
+++ b/src/main/java/org/example/service/ClienteServiceImpl.java
@@ -1,16 +1,18 @@
 package org.example.service;
 
 import org.example.model.Cliente;
+import org.example.repository.ClienteRepository;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 
 public class ClienteServiceImpl implements ClienteService {
-    Map<String, Cliente> listaClientes = new HashMap<>();
+    private final ClienteRepository clienteRepository;
 
+    public ClienteServiceImpl(ClienteRepository clienteRepository) {
+        this.clienteRepository = clienteRepository;
+    }
 
     @Override
     public Cliente cadastrarCliente(String nomeCompleto, String cpf, String endereco) throws Exception {
@@ -21,12 +23,12 @@ public class ClienteServiceImpl implements ClienteService {
             throw new Exception("Preencha todos os campos");
         }
 
-        if (listaClientes.containsKey(cpf)) {
+        if (clienteRepository.buscarPorCPF(cpf) != null) {
             throw new Exception("CPF já cadastrado");
         }
 
         var clienteCadastrar = new Cliente(nomeCompleto, cpf, endereco);
-        listaClientes.put(cpf, clienteCadastrar);
+        clienteRepository.cadastrar(clienteCadastrar);
 
         return clienteCadastrar;
     }
@@ -48,7 +50,7 @@ public class ClienteServiceImpl implements ClienteService {
         }
 
         var clienteAtualizar = new Cliente(nomeCompleto, cpf, endereco);
-        listaClientes.put(cpf, clienteAtualizar);
+        clienteRepository.cadastrar(clienteAtualizar);
 
         return clienteAtualizar;
     }
@@ -59,7 +61,7 @@ public class ClienteServiceImpl implements ClienteService {
             throw new Exception("O CPF informado não foi encontrado. Tente novamente");
         }
 
-        return listaClientes.get(cpf);
+        return clienteRepository.buscarPorCPF(cpf);
     }
 
     @Override
@@ -67,7 +69,7 @@ public class ClienteServiceImpl implements ClienteService {
         List<Cliente> clientesEncontrados = new ArrayList<>();
         String nomePesquisa = nome.toLowerCase();
 
-        for (Cliente cliente : listaClientes.values()) {
+        for (Cliente cliente : clienteRepository.buscarValores(nome)) {
             if (cliente.getNomeCompleto().toLowerCase().contains(nomePesquisa)) {
                 clientesEncontrados.add(cliente);
             }

--- a/src/main/java/org/example/service/ContaServiceImpl.java
+++ b/src/main/java/org/example/service/ContaServiceImpl.java
@@ -2,19 +2,19 @@ package org.example.service;
 
 import org.example.model.Cliente;
 import org.example.model.Conta;
+import org.example.repository.ContaRepository;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class ContaServiceImpl implements ContaService {
-    private final Map<String, Conta> contaRepository;
+    private final ContaRepository contaRepository;
 
     private final ClienteService clienteService;
 
-    public ContaServiceImpl(ClienteService clienteService, Map<String, Conta> contaRepository) {
-        this.clienteService = clienteService;
+    public ContaServiceImpl(ContaRepository contaRepository, ClienteService clienteService) {
         this.contaRepository = contaRepository;
+        this.clienteService = clienteService;
     }
 
     @Override
@@ -38,7 +38,7 @@ public class ContaServiceImpl implements ContaService {
             throw new Exception("O saldo deve ser um número maior que zero.\n");
         }
 
-        var numeroConta = String.valueOf(contaRepository.size());
+        var numeroConta = String.valueOf(contaRepository.buscarTamanho());
 
         Cliente cliente = clienteService.buscarClientePorCPF(cpf);
         if (cliente == null) {
@@ -46,14 +46,15 @@ public class ContaServiceImpl implements ContaService {
         }
 
         var conta = new Conta(numeroConta, cliente, saldo, true);
-        contaRepository.put(numeroConta, conta);
+        contaRepository.cadastrar(conta);
 
         return conta;
     }
 
     @Override
     public Conta buscarContaPorNumero(String numeroConta) throws Exception {
-        Conta conta = contaRepository.get(numeroConta);
+        Conta conta = contaRepository.buscarPorNumero(numeroConta);
+
         if (numeroConta == null || numeroConta.trim().isEmpty() || conta == null) {
             throw new Exception("A conta informada não foi encontrada. Cadastre-se e tente novamente.\n");
         }
@@ -69,7 +70,7 @@ public class ContaServiceImpl implements ContaService {
     public List<Conta> buscarContasPorTitular(String nomeCompleto) throws Exception {
         List<Conta> contasEncontradas = new ArrayList<>();
 
-        for (Conta conta : contaRepository.values()) {
+        for (Conta conta : contaRepository.buscarValores(nomeCompleto)) {
             if (conta.getTitular().getNomeCompleto().equals(nomeCompleto) && conta.isAtivo()) {
                 contasEncontradas.add(conta);
             }
@@ -86,7 +87,7 @@ public class ContaServiceImpl implements ContaService {
     public List<Conta> buscarContasPorCPF(String cpf) throws Exception {
         List<Conta> contasEncontradas = new ArrayList<>();
 
-        for (Conta conta : contaRepository.values()) {
+        for (Conta conta : contaRepository.buscarValores(cpf)) {
             if (conta.getTitular().getCpf().equals(cpf) && conta.isAtivo()) {
                 contasEncontradas.add(conta);
             }
@@ -103,6 +104,7 @@ public class ContaServiceImpl implements ContaService {
     public Conta desativarConta(String numeroConta) throws Exception {
         Conta conta = buscarContaPorNumero(numeroConta);
 
+        contaRepository.cadastrar(conta);
         conta.setAtivo(false);
 
         return conta;

--- a/src/test/java/org/example/controller/CartaoControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/CartaoControllerIntegrationTest.java
@@ -20,11 +20,11 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CartaoControllerIntegrationTest {
-
     @InjectMocks
     private CartaoController controller;
 
     private Scanner scanner;
+
     private TesteInputStream inputStream;
 
     @Mock
@@ -44,6 +44,7 @@ public class CartaoControllerIntegrationTest {
     @BeforeEach
     public void setup() {
         inputStream = new TesteInputStream();
+
         scanner = new Scanner(inputStream);
 
         //Redireciona o System.in para p nosso inputStream
@@ -61,6 +62,7 @@ public class CartaoControllerIntegrationTest {
                 | Cadastrar                      |
                 ----------------------------------""";
         var resultadoReal = controller.executar("cartoes");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 

--- a/src/test/java/org/example/controller/ClienteControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClienteControllerIntegrationTest.java
@@ -1,25 +1,41 @@
 package org.example.controller;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Scanner;
 
+import org.example.model.Cliente;
 import org.example.service.ClienteService;
-import org.example.service.ClienteServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class ClienteControllerIntegrationTest {
+    @InjectMocks
     private ClienteController controller;
+
     private Scanner scanner;
+
     private TesteInputStream inputStream;
+
+    @Mock
     private ClienteService clienteService;
+
+    private static final String NOME_CLIENTE = "Kevelly";
+    private static final String CPF_CLIENTE = "12345678900";
+    private static final String ENDERECO_CLIENTE = "Rua dos testes, 56";
 
     @BeforeEach
     public void setup() {
-        clienteService = new ClienteServiceImpl();
         inputStream = new TesteInputStream();
+
         scanner = new Scanner(inputStream);
 
         //Redireciona o System.in para p nosso inputStream
@@ -38,6 +54,7 @@ public class ClienteControllerIntegrationTest {
                 | pesquisar                  |
                 ------------------------------""";
         var resultadoReal = controller.executar("clientes");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
@@ -45,33 +62,38 @@ public class ClienteControllerIntegrationTest {
     public void quandoComandoEhClientesCadastrarEntaoCadastreOsClientes() throws Exception {
         //o \n é um delimitador para o Scanner(espaço e tabulação também),
         //sempre q ele lê sabe acabou e passa para a próxima linha
-        this.inputStream.setInputs("Kevelly\n0123456789\nRua Ficticia 123\n");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteService.cadastrarCliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE)).thenReturn(cliente);
+        when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
+        this.inputStream.setInputs("Kevelly\n12345678900\nRua dos testes, 56\n");
         var resultadoEsperado = "Cliente cadastrado com sucesso\n";
         var resultadoReal = controller.executar("clientes cadastrar");
         assertEquals(resultadoEsperado, resultadoReal);
 
-        var cliente = clienteService.buscarClientePorCPF("0123456789");
-        assertEquals("Kevelly", cliente.getNomeCompleto());
-        assertEquals("0123456789", cliente.getCpf());
-        assertEquals("Rua Ficticia 123", cliente.getEndereco());
+        var resultado = clienteService.buscarClientePorCPF(CPF_CLIENTE);
+        assertEquals(NOME_CLIENTE, resultado.getNomeCompleto());
+        assertEquals(CPF_CLIENTE, resultado.getCpf());
+        assertEquals(ENDERECO_CLIENTE, resultado.getEndereco());
     }
 
     @Test
     public void quandoComandoEhClientesAtualizarEntaoAtualizeOsClientes() throws Exception {
-        this.inputStream.setInputs("Kevelly\n0123456789\nRua Fictícia 123\n");
-        controller.executar("clientes cadastrar");
+        Cliente clienteAtualizado = new Cliente("Joice", CPF_CLIENTE, "Rua Teste 234");
+        when(clienteService.atualizarCliente("Joice", CPF_CLIENTE, "Rua Teste 234")).
+                thenReturn(clienteAtualizado);
+        when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(clienteAtualizado);
 
-        this.inputStream.setInputs("Kevelly\nRua Teste 234\n");
+        this.inputStream.setInputs("Joice\nRua Teste 234\n");
         var resultadoEsperado = "Cliente atualizado com sucesso\n";
-
-        var resultadoReal = controller.executar("clientes atualizar 0123456789");
-
+        var resultadoReal = controller.executar("clientes atualizar 12345678900");
         assertEquals(resultadoEsperado, resultadoReal);
-        var cliente = clienteService.buscarClientePorCPF("0123456789");
-        assertEquals("Kevelly", cliente.getNomeCompleto());
-        assertEquals("0123456789", cliente.getCpf());
-        assertEquals("Rua Teste 234", cliente.getEndereco());
+
+        var resultado = clienteService.buscarClientePorCPF(CPF_CLIENTE);
+
+        assertEquals("Joice", resultado.getNomeCompleto());
+        assertEquals(CPF_CLIENTE, resultado.getCpf());
+        assertEquals("Rua Teste 234", resultado.getEndereco());
     }
 
     @Test
@@ -92,7 +114,6 @@ public class ClienteControllerIntegrationTest {
     @Test
     public void quandoComandoEhClientesAtualizarECpfNaoEhInformadoEntaoRetorneErro() throws Exception {
         var resultadoEsperado = "Para atualizar é necessário informar o CPF. Ex: clientes atualizar 12345678901.\n";
-
         var resultadoReal = controller.executar("clientes atualizar");
 
         assertEquals(resultadoEsperado, resultadoReal);
@@ -102,6 +123,7 @@ public class ClienteControllerIntegrationTest {
     public void quandoComandoEhClientesDesativarEntaoDesativeOsClientes() throws Exception {
         var resultadoEsperado = "não implementado";
         var resultadoReal = controller.executar("clientes desativar");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
@@ -113,46 +135,48 @@ public class ClienteControllerIntegrationTest {
                 | nome {nome do cliente} |
                 -------------------------""";
         var resultadoReal = controller.executar("clientes pesquisar");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhClientesPesquisarNomeEEncontrarClientesEntaoExibaListaDeClientes() throws Exception {
-        this.inputStream.setInputs("Kevelly\n0987654321\nRua Ficticia 123\n");
-        controller.executar("clientes cadastrar");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        Cliente cliente2 = new Cliente(NOME_CLIENTE, "98765432100", ENDERECO_CLIENTE);
 
-        this.inputStream.setInputs("Kevelly\n1234567890\nRua Ficticia 123\n");
-        controller.executar("clientes cadastrar");
+        List<Cliente> clientes = new ArrayList<>();
+        clientes.add(cliente);
+        clientes.add(cliente2);
 
-        clienteService.pesquisarClientePorNome("Kevelly");
+        when(clienteService.pesquisarClientePorNome("Kevelly")).thenReturn(clientes);
 
         var resultadoEsperado = "Clientes encontrados: \n" +
-                "Cliente Kevelly, de CPF 1234567890 e endereço Rua Ficticia 123.\n" +
-                "Cliente Kevelly, de CPF 0987654321 e endereço Rua Ficticia 123.\n";
-
+                "Cliente Kevelly, de CPF 12345678900 e endereço Rua dos testes, 56.\n" +
+                "Cliente Kevelly, de CPF 98765432100 e endereço Rua dos testes, 56.\n";
         var resultadoReal = controller.executar("clientes pesquisar nome Kevelly");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
+
 
     @Test
     public void quandoComandoEhClientesPesquisarNomeENaoEncontrarClientesEntaoRetorneErro() throws Exception {
         clienteService.pesquisarClientePorNome("Kevelly");
 
         var resultadoEsperado = "Cliente não encontrado. Cadastre-se e tente novamente.\n";
-
         var resultadoReal = controller.executar("clientes pesquisar nome Kevelly");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhClientesPesquisarCpfEEncontrarClienteEntaoRetorneSuasInformacoes() throws Exception {
-        quandoComandoEhClientesCadastrarEntaoCadastreOsClientes();
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
-        clienteService.buscarClientePorCPF("0123456789");
+        var resultadoEsperado = "Cliente Kevelly, de CPF 12345678900 e endereço Rua dos testes, 56.";
+        var resultadoReal = controller.executar("clientes pesquisar cpf 12345678900");
 
-        var resultadoEsperado = "Cliente Kevelly, de CPF 0123456789 e endereço Rua Ficticia 123.";
-
-        var resultadoReal = controller.executar("clientes pesquisar cpf 0123456789");
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
@@ -161,8 +185,8 @@ public class ClienteControllerIntegrationTest {
         clienteService.buscarClientePorCPF("0123456789");
 
         var resultadoEsperado = "Cliente não encontrado. Cadastre-se e tente novamente.\n";
-
         var resultadoReal = controller.executar("clientes pesquisar cpf 0123456789");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 

--- a/src/test/java/org/example/controller/ClienteControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ClienteControllerIntegrationTest.java
@@ -63,15 +63,18 @@ public class ClienteControllerIntegrationTest {
         //o \n é um delimitador para o Scanner(espaço e tabulação também),
         //sempre q ele lê sabe acabou e passa para a próxima linha
         Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+
         when(clienteService.cadastrarCliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE)).thenReturn(cliente);
         when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
         this.inputStream.setInputs("Kevelly\n12345678900\nRua dos testes, 56\n");
         var resultadoEsperado = "Cliente cadastrado com sucesso\n";
         var resultadoReal = controller.executar("clientes cadastrar");
+
         assertEquals(resultadoEsperado, resultadoReal);
 
         var resultado = clienteService.buscarClientePorCPF(CPF_CLIENTE);
+
         assertEquals(NOME_CLIENTE, resultado.getNomeCompleto());
         assertEquals(CPF_CLIENTE, resultado.getCpf());
         assertEquals(ENDERECO_CLIENTE, resultado.getEndereco());
@@ -80,6 +83,7 @@ public class ClienteControllerIntegrationTest {
     @Test
     public void quandoComandoEhClientesAtualizarEntaoAtualizeOsClientes() throws Exception {
         Cliente clienteAtualizado = new Cliente("Joice", CPF_CLIENTE, "Rua Teste 234");
+
         when(clienteService.atualizarCliente("Joice", CPF_CLIENTE, "Rua Teste 234")).
                 thenReturn(clienteAtualizado);
         when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(clienteAtualizado);
@@ -87,6 +91,7 @@ public class ClienteControllerIntegrationTest {
         this.inputStream.setInputs("Joice\nRua Teste 234\n");
         var resultadoEsperado = "Cliente atualizado com sucesso\n";
         var resultadoReal = controller.executar("clientes atualizar 12345678900");
+
         assertEquals(resultadoEsperado, resultadoReal);
 
         var resultado = clienteService.buscarClientePorCPF(CPF_CLIENTE);
@@ -172,6 +177,7 @@ public class ClienteControllerIntegrationTest {
     @Test
     public void quandoComandoEhClientesPesquisarCpfEEncontrarClienteEntaoRetorneSuasInformacoes() throws Exception {
         Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+
         when(clienteService.buscarClientePorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
         var resultadoEsperado = "Cliente Kevelly, de CPF 12345678900 e endereço Rua dos testes, 56.";

--- a/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
+++ b/src/test/java/org/example/controller/ContaControllerIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ContaControllerIntegrationTest {
-
     @InjectMocks
     private ContaController controller;
 
@@ -40,6 +39,7 @@ public class ContaControllerIntegrationTest {
     @BeforeEach
     public void setup() {
         inputStream = new TesteInputStream();
+
         scanner = new Scanner(inputStream);
 
         //Redireciona o System.in para p nosso inputStream
@@ -58,14 +58,15 @@ public class ContaControllerIntegrationTest {
                 | pesquisar                   |
                 -------------------------------""";
         var resultadoReal = controller.executar("contas");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhContasCadastrarEntaoCadastreAsContas() throws Exception {
         var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
-
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
+
         when(contaService.cadastrarConta(CPF_CLIENTE, String.valueOf(SALDO_CONTA))).thenReturn(conta);
 
         var resultadoEsperado = "Conta cadastrada com sucesso!\n" +
@@ -115,6 +116,7 @@ public class ContaControllerIntegrationTest {
     public void quandoComandoEhContasExtratoEntaoExibaOExtradoDasContas() throws Exception {
         var resultadoEsperado = "não implementado";
         var resultadoReal = controller.executar("contas extrato");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
@@ -127,13 +129,13 @@ public class ContaControllerIntegrationTest {
                 | numero {número da conta}       |
                 ----------------------------------""";
         var resultadoReal = controller.executar("contas pesquisar");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhContasPesquisarCpfTitularEntaoExibaAsContasEncontradas() throws Exception {
         var cliente1 = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
-
         var clienteConta1 = new Conta(NUMERO_CONTA, cliente1, SALDO_CONTA, IS_ATIVO_CONTA);
         var clienteConta2 = new Conta("1", cliente1, 5000.0, true);
 
@@ -157,13 +159,13 @@ public class ContaControllerIntegrationTest {
                 "Endereço: Rua dos testes, 56.\n" +
                 "\n";
         var resultadoReal = controller.executar("contas pesquisar cpf-titular 12345678900");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhContasPesquisarNomeTitularEntaoExibaAsContasEncontradas() throws Exception {
         var cliente1 = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
-
         var clienteConta1 = new Conta(NUMERO_CONTA, cliente1, SALDO_CONTA, IS_ATIVO_CONTA);
         var clienteConta2 = new Conta("1", cliente1, 5000.0, true);
 
@@ -187,14 +189,15 @@ public class ContaControllerIntegrationTest {
                 "Endereço: Rua dos testes, 56.\n" +
                 "\n";
         var resultadoReal = controller.executar("contas pesquisar nome-titular Kevelly");
+
         assertEquals(resultadoEsperado, resultadoReal);
     }
 
     @Test
     public void quandoComandoEhContasPesquisarNumeroEntaoExibaDetalhesDaConta() throws Exception {
         var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
-
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
+
         when(contaService.buscarContaPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         var resultadoEsperado = "Conta encontrada: \n" +

--- a/src/test/java/org/example/service/CartaoServiceImplTest.java
+++ b/src/test/java/org/example/service/CartaoServiceImplTest.java
@@ -169,7 +169,7 @@ public class CartaoServiceImplTest {
         Cartao resultado = cartaoServiceImpl.bloquearCartao(NUMERO_CARTAO);
 
         assertEquals(CPF_CLIENTE, resultado.getCliente().getCpf());
-        assertFalse(resultado.isBloqueado());
+        assertTrue(resultado.isBloqueado());
     }
 
     @Test
@@ -199,6 +199,6 @@ public class CartaoServiceImplTest {
         Cartao resultado = cartaoServiceImpl.desbloquearCartao(NUMERO_CARTAO);
 
         assertEquals(CPF_CLIENTE, resultado.getCliente().getCpf());
-        assertTrue(resultado.isBloqueado());
+        assertFalse(resultado.isBloqueado());
     }
 }

--- a/src/test/java/org/example/service/CartaoServiceImplTest.java
+++ b/src/test/java/org/example/service/CartaoServiceImplTest.java
@@ -3,6 +3,7 @@ package org.example.service;
 import org.example.model.Cartao;
 import org.example.model.Cliente;
 import org.example.model.Conta;
+import org.example.repository.CartaoRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,8 +11,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,7 +31,7 @@ public class CartaoServiceImplTest {
     private ContaService contaService;
 
     @Mock
-    private HashMap<String, Cartao> mockHashMapCartao;
+    private CartaoRepository cartaoRepository;
 
     private static final String NOME_CLIENTE = "Kevelly";
     private static final String CPF_CLIENTE = "12345678900";
@@ -55,7 +54,6 @@ public class CartaoServiceImplTest {
         when(contaService.buscarContaPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         Cartao resultadoReal = cartaoServiceImpl.cadastrarCartao(CPF_CLIENTE, NUMERO_CONTA);
-
         assertEquals(cliente, resultadoReal.getCliente());
         assertEquals(conta, resultadoReal.getConta());
     }
@@ -125,7 +123,7 @@ public class CartaoServiceImplTest {
         Conta conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
         Cartao cartao = new Cartao(NUMERO_CARTAO, CVV_CARTAO, DT_VENCIMENTO_CARTAO, cliente, conta, IS_BLOQUEADO_CARTAO);
 
-        when(mockHashMapCartao.get(NUMERO_CARTAO)).thenReturn(cartao);
+        when(cartaoRepository.buscarPorNumero(NUMERO_CARTAO)).thenReturn(cartao);
 
         Cartao resultadoReal = cartaoServiceImpl.buscarCartaoPorNumero(NUMERO_CARTAO);
 
@@ -150,12 +148,12 @@ public class CartaoServiceImplTest {
         Conta conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
         Cartao cartao = new Cartao(NUMERO_CARTAO, CVV_CARTAO, DT_VENCIMENTO_CARTAO, cliente, conta, true);
 
-        when(mockHashMapCartao.get(NUMERO_CARTAO)).thenReturn(cartao);
+        when(cartaoRepository.buscarPorNumero(NUMERO_CARTAO)).thenReturn(cartao);
 
         Exception exception = assertThrows(Exception.class, () ->
                 cartaoServiceImpl.bloquearCartao(NUMERO_CARTAO)
         );
-        assertEquals("Esse cartão está bloqueado.\n",
+        assertEquals("Esse cartão já está bloqueado.\n",
                 exception.getMessage());
     }
 
@@ -166,12 +164,12 @@ public class CartaoServiceImplTest {
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
         var cartao = new Cartao(NUMERO_CARTAO, CVV_CARTAO, DT_VENCIMENTO_CARTAO, cliente, conta, IS_BLOQUEADO_CARTAO);
 
-        when(mockHashMapCartao.get(NUMERO_CARTAO)).thenReturn(cartao);
+        when(cartaoRepository.buscarPorNumero(NUMERO_CARTAO)).thenReturn(cartao);
 
         Cartao resultado = cartaoServiceImpl.bloquearCartao(NUMERO_CARTAO);
 
         assertEquals(CPF_CLIENTE, resultado.getCliente().getCpf());
-        assertTrue(resultado.isBloqueado());
+        assertFalse(resultado.isBloqueado());
     }
 
     @Test
@@ -180,12 +178,12 @@ public class CartaoServiceImplTest {
         Conta conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
         Cartao cartao = new Cartao(NUMERO_CARTAO, CVV_CARTAO, DT_VENCIMENTO_CARTAO, cliente, conta, IS_BLOQUEADO_CARTAO);
 
-        when(mockHashMapCartao.get(NUMERO_CARTAO)).thenReturn(cartao);
+        when(cartaoRepository.buscarPorNumero(NUMERO_CARTAO)).thenReturn(cartao);
 
         Exception exception = assertThrows(Exception.class, () ->
                 cartaoServiceImpl.desbloquearCartao(NUMERO_CARTAO)
         );
-        assertEquals("Esse cartão está desbloqueado.\n",
+        assertEquals("Esse cartão já está desbloqueado.\n",
                 exception.getMessage());
     }
 
@@ -196,11 +194,11 @@ public class CartaoServiceImplTest {
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
         var cartao = new Cartao(NUMERO_CARTAO, CVV_CARTAO, DT_VENCIMENTO_CARTAO, cliente, conta, true);
 
-        when(mockHashMapCartao.get(NUMERO_CARTAO)).thenReturn(cartao);
+        when(cartaoRepository.buscarPorNumero(NUMERO_CARTAO)).thenReturn(cartao);
 
         Cartao resultado = cartaoServiceImpl.desbloquearCartao(NUMERO_CARTAO);
 
         assertEquals(CPF_CLIENTE, resultado.getCliente().getCpf());
-        assertFalse(resultado.isBloqueado());
+        assertTrue(resultado.isBloqueado());
     }
 }

--- a/src/test/java/org/example/service/CartaoServiceImplTest.java
+++ b/src/test/java/org/example/service/CartaoServiceImplTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CartaoServiceImplTest {
-
     @InjectMocks
     private CartaoServiceImpl cartaoServiceImpl;
 
@@ -54,6 +53,7 @@ public class CartaoServiceImplTest {
         when(contaService.buscarContaPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         Cartao resultadoReal = cartaoServiceImpl.cadastrarCartao(CPF_CLIENTE, NUMERO_CONTA);
+
         assertEquals(cliente, resultadoReal.getCliente());
         assertEquals(conta, resultadoReal.getConta());
     }

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -1,37 +1,42 @@
 package org.example.service;
 
 import org.example.model.Cliente;
-import org.junit.jupiter.api.BeforeEach;
+import org.example.repository.ClienteRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class ClienteServiceImplTest {
+
+    @InjectMocks
     private ClienteServiceImpl clientesServiceImpl;
 
-    @BeforeEach
-    public void setup() {
-        clientesServiceImpl = new ClienteServiceImpl();
-    }
+    @Mock
+    private ClienteRepository clienteRepository;
+
+    private static final String NOME_CLIENTE = "Kevelly";
+    private static final String CPF_CLIENTE = "12345678900";
+    private static final String ENDERECO_CLIENTE = "Rua dos testes 56";
 
     @Test
     public void quandoClientesCadastrarVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso() throws Exception {
-        var resultado = clientesServiceImpl.cadastrarCliente(
-                "Kevelly",
-                "5689778",
-                "Rua teste");
+        Cliente cliente = clientesServiceImpl.cadastrarCliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
-        Cliente cliente = clientesServiceImpl.buscarClientePorCPF("5689778");
-
-        assertEquals(cliente, resultado);
-        assertEquals("Kevelly", cliente.getNomeCompleto());
-        assertEquals("5689778", cliente.getCpf());
-        assertEquals("Rua teste", cliente.getEndereco());
+        assertEquals(NOME_CLIENTE, cliente.getNomeCompleto());
+        assertEquals(CPF_CLIENTE, cliente.getCpf());
+        assertEquals(ENDERECO_CLIENTE, cliente.getEndereco());
     }
 
     @ParameterizedTest
@@ -48,113 +53,105 @@ public class ClienteServiceImplTest {
             "Kevelly, 12345678900, ''",
             "'', '', ''",
     })
-    void quandoClientesCadastrarENomeForNuloOuVazioEntaoRetorneMensagemDeErro(
-            String nomeCompleto, String cpf, String endereco) throws Exception {
+    void quandoClientesCadastrarENomeForNuloOuVazioEntaoRetorneMensagemDeErro(String nomeCompleto,
+                                                                              String cpf,
+                                                                              String endereco) {
         Exception exception = assertThrows(Exception.class, () ->
-                clientesServiceImpl.cadastrarCliente(nomeCompleto, cpf, endereco));
-
+                clientesServiceImpl.cadastrarCliente(nomeCompleto, cpf, endereco)
+        );
         assertEquals("Preencha todos os campos", exception.getMessage());
     }
 
     @Test
-    public void quandoClientesCadastrarEntaoVerifiqueSeCadastrouChaveAntes() throws Exception {
-        clientesServiceImpl.cadastrarCliente(
-                "Joao",
-                "5689778",
-                "Rua teste");
+    public void quandoClientesCadastrarEntaoVerifiqueSeCadastrouChaveAntes() {
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
 
+        when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
         // () -> : lambda expression
         Exception exception = assertThrows(Exception.class, () ->
-                clientesServiceImpl.cadastrarCliente(
-                        "Kevelly",
-                        "5689778",
-                        "Rua teste"));
-
+                clientesServiceImpl.cadastrarCliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE)
+        );
         assertEquals("CPF já cadastrado", exception.getMessage());
     }
 
     // Verificação do pesquisar CPF
     @ParameterizedTest
     @NullAndEmptySource //quando a função for executada passa null e depois vazia
-    public void quandoBuscarClientePorCpfForVazioOuNuloEntaoNaoRealizarCadastro(String cpf) throws Exception {
-
+    public void quandoBuscarClientePorCpfForVazioOuNuloEntaoNaoRealizarCadastro(String cpf) {
         Exception exception = assertThrows(Exception.class, () -> {
             clientesServiceImpl.buscarClientePorCPF(cpf);
-
-            clientesServiceImpl.cadastrarCliente(
-                    "Kevelly",
-                    cpf,
-                    "Rua teste");
+            clientesServiceImpl.cadastrarCliente(NOME_CLIENTE, cpf, ENDERECO_CLIENTE);
         });
         assertEquals("O CPF informado não foi encontrado. Tente novamente", exception.getMessage());
     }
 
-
     //TESTE ATUALIZAR
     @Test
     public void quandoClienteAtualizarVerifiqueSeOCpfJaFoiCadastradoEntaoAtualizeComSucesso() throws Exception {
-        quandoClientesCadastrarVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso();
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
-        var resultado = clientesServiceImpl.atualizarCliente(
-                "Joana",
-                "5689778",
-                "Rua teste da silva");
+        Cliente novoCliente = clientesServiceImpl.atualizarCliente("Joana", CPF_CLIENTE, "Rua teste da silva");
 
-        Cliente cliente = clientesServiceImpl.buscarClientePorCPF("5689778");
-
-        assertEquals(cliente, resultado);
-        assertEquals("Joana", cliente.getNomeCompleto());
-        assertEquals("5689778", cliente.getCpf());
-        assertEquals("Rua teste da silva", cliente.getEndereco());
+        assertEquals("Joana", novoCliente.getNomeCompleto());
+        assertEquals(CPF_CLIENTE, novoCliente.getCpf());
+        assertEquals("Rua teste da silva", novoCliente.getEndereco());
     }
 
     @ParameterizedTest
     //permite executar o mesmo teste várias vezes com valores diferentes
-    //Simula a entrada vazia, esperando que o nome continue "Kevelly"
+    //Simula a entrada vazia, esperando que o nome continue NOME_CLIENTE
     @CsvSource({" , Kevelly"})
     public void quandoClienteAtualizarVerfiqueSeNomeCompletoEhVazioEntaoRetorneSeuValorAnterior
             (String novoNome, String nomeEsperado) throws Exception {
-        clientesServiceImpl.cadastrarCliente("Kevelly", "5689778", "Rua teste");
-        Cliente cliente = clientesServiceImpl.buscarClientePorCPF("5689778");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
         //Simula o input vazio
         if (novoNome == null) {
             novoNome = cliente.getNomeCompleto();
         }
 
-        clientesServiceImpl.atualizarCliente(novoNome, "5689778", "Rua teste");
+        clientesServiceImpl.atualizarCliente(novoNome, CPF_CLIENTE, ENDERECO_CLIENTE);
 
         //Valida se o nome continua o mesmo
-        Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF("5689778");
+        Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);
         assertEquals(nomeEsperado, clienteAtualizado.getNomeCompleto());
     }
 
     @ParameterizedTest
     //permite executar o mesmo teste várias vezes com valores diferentes
-    @CsvSource({" , rua Unitarios 123"})
+    @CsvSource({" , Rua dos testes 56"})
     public void quandoAtualizarClienteVerfiqueSeEnderecoEhVazioEntaoRetorneSeuValorAnterior
             (String novoEndereco, String enderecoEsperado) throws Exception {
-        clientesServiceImpl.cadastrarCliente("Kevelly", "5689778", "rua Unitarios 123");
-        Cliente cliente = clientesServiceImpl.buscarClientePorCPF("5689778");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
         if (novoEndereco == null) {
             novoEndereco = cliente.getEndereco();
         }
 
-        clientesServiceImpl.atualizarCliente("Ana", "5689778", novoEndereco);
+        clientesServiceImpl.atualizarCliente("Ana", CPF_CLIENTE, novoEndereco);
 
-        Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF("5689778");
+        Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);
         assertEquals(enderecoEsperado, clienteAtualizado.getEndereco());
     }
 
     //PESQUISAR CLIENTE
     @Test
     public void quandoClientePesquisarNomeEntaoListeTodosOsClientesComEsseNome() throws Exception {
-        clientesServiceImpl.cadastrarCliente("Kevelly", "1111111", "rua Unitarios 123");
-        clientesServiceImpl.cadastrarCliente("Joana Silva", "0000000", "rua Unitarios 123");
-        clientesServiceImpl.cadastrarCliente("Carol silveira", "9999999", "rua Unitarios 123");
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        Cliente cliente2 = new Cliente("Joana Silva", "0000000", "rua Unitarios 123");
+        Cliente cliente3 = new Cliente("Carol silveira", "9999999", "rua Unitarios 123");
+
+        List<Cliente> clientes = new ArrayList<>();
+        clientes.add(cliente);
+        clientes.add(cliente2);
+        clientes.add(cliente3);
 
         var busca = "sil";
+
+        when(clienteRepository.buscarValores(busca)).thenReturn(clientes);
 
         List<Cliente> resultado = clientesServiceImpl.pesquisarClientePorNome(busca);
 
@@ -173,12 +170,13 @@ public class ClienteServiceImplTest {
 
     @Test
     public void quandoClientePesquisarCpfEntaoExibaOClienteComEsseCpf() throws Exception {
-        quandoClientesCadastrarVerifiqueSeOCpfJaFoiCadastradoEntaoCadastreComSucesso();
+        Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+        when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
-        Cliente resultado = clientesServiceImpl.buscarClientePorCPF("5689778");
+        Cliente resultado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);
 
-        assertEquals("Kevelly", resultado.getNomeCompleto());
-        assertEquals("5689778", resultado.getCpf());
-        assertEquals("Rua teste", resultado.getEndereco());
+        assertEquals(NOME_CLIENTE, resultado.getNomeCompleto());
+        assertEquals(CPF_CLIENTE, resultado.getCpf());
+        assertEquals(ENDERECO_CLIENTE, resultado.getEndereco());
     }
 }

--- a/src/test/java/org/example/service/ClienteServiceImplTest.java
+++ b/src/test/java/org/example/service/ClienteServiceImplTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ClienteServiceImplTest {
-
     @InjectMocks
     private ClienteServiceImpl clientesServiceImpl;
 
@@ -113,9 +112,8 @@ public class ClienteServiceImplTest {
         }
 
         clientesServiceImpl.atualizarCliente(novoNome, CPF_CLIENTE, ENDERECO_CLIENTE);
-
-        //Valida se o nome continua o mesmo
         Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);
+
         assertEquals(nomeEsperado, clienteAtualizado.getNomeCompleto());
     }
 
@@ -132,8 +130,8 @@ public class ClienteServiceImplTest {
         }
 
         clientesServiceImpl.atualizarCliente("Ana", CPF_CLIENTE, novoEndereco);
-
         Cliente clienteAtualizado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);
+
         assertEquals(enderecoEsperado, clienteAtualizado.getEndereco());
     }
 
@@ -150,9 +148,7 @@ public class ClienteServiceImplTest {
         clientes.add(cliente3);
 
         var busca = "sil";
-
         when(clienteRepository.buscarValores(busca)).thenReturn(clientes);
-
         List<Cliente> resultado = clientesServiceImpl.pesquisarClientePorNome(busca);
 
         // Testando usando a função get da lista (modo imperativo)
@@ -171,6 +167,7 @@ public class ClienteServiceImplTest {
     @Test
     public void quandoClientePesquisarCpfEntaoExibaOClienteComEsseCpf() throws Exception {
         Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
+
         when(clienteRepository.buscarPorCPF(CPF_CLIENTE)).thenReturn(cliente);
 
         Cliente resultado = clientesServiceImpl.buscarClientePorCPF(CPF_CLIENTE);

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -2,6 +2,7 @@ package org.example.service;
 
 import org.example.model.Cliente;
 import org.example.model.Conta;
+import org.example.repository.ContaRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,7 +27,7 @@ public class ContaServiceImplTest {
     private ClienteService clienteService;
 
     @Mock
-    private HashMap<String, Conta> mockHashMapConta;
+    private ContaRepository contaRepository;
 
     private static final String NOME_CLIENTE = "Kevelly";
     private static final String CPF_CLIENTE = "12345678900";
@@ -103,7 +103,7 @@ public class ContaServiceImplTest {
         Cliente cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
         Conta conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, false);
 
-        when(mockHashMapConta.get(NUMERO_CONTA)).thenReturn(conta);
+        when(contaRepository.buscarPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         Exception exception = assertThrows(Exception.class, () ->
                 contaServiceImpl.buscarContaPorNumero(NUMERO_CONTA)
@@ -125,7 +125,7 @@ public class ContaServiceImplTest {
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
 
         // Mocka o comportamento
-        when(mockHashMapConta.values()).thenReturn(List.of(conta));
+        when(contaRepository.buscarValores(NOME_CLIENTE)).thenReturn(List.of(conta));
 
         // Chama o metodo mockado
         List<Conta> resultado = contaServiceImpl.buscarContasPorTitular(NOME_CLIENTE);
@@ -146,7 +146,7 @@ public class ContaServiceImplTest {
         var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
 
-        when(mockHashMapConta.values()).thenReturn(List.of(conta));
+        when(contaRepository.buscarValores(CPF_CLIENTE)).thenReturn(List.of(conta));
 
         List<Conta> resultado = contaServiceImpl.buscarContasPorCPF(CPF_CLIENTE);
 
@@ -160,7 +160,7 @@ public class ContaServiceImplTest {
         var cliente = new Cliente(NOME_CLIENTE, CPF_CLIENTE, ENDERECO_CLIENTE);
         var conta = new Conta(NUMERO_CONTA, cliente, SALDO_CONTA, IS_ATIVO_CONTA);
 
-        when(mockHashMapConta.get(NUMERO_CONTA)).thenReturn(conta);
+        when(contaRepository.buscarPorNumero(NUMERO_CONTA)).thenReturn(conta);
 
         Conta resultado = contaServiceImpl.desativarConta(NUMERO_CONTA);
 

--- a/src/test/java/org/example/service/ContaServiceImplTest.java
+++ b/src/test/java/org/example/service/ContaServiceImplTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ContaServiceImplTest {
-
     @InjectMocks
     private ContaServiceImpl contaServiceImpl;
 
@@ -70,10 +69,9 @@ public class ContaServiceImplTest {
     @ParameterizedTest
     @ValueSource(strings = {"aaa", "abc", "123abc", "@"})
     public void quandoContasCadastrarESaldoForValorInvalidoEntaoExibaMensagem(String saldoStr) {
-        Exception exception = assertThrows(Exception.class, () -> {
-            contaServiceImpl.cadastrarConta(CPF_CLIENTE, saldoStr);
-
-        });
+        Exception exception = assertThrows(Exception.class, () ->
+                contaServiceImpl.cadastrarConta(CPF_CLIENTE, saldoStr)
+        );
         assertEquals("O saldo deve ser um número válido.\n", exception.getMessage());
     }
 
@@ -81,10 +79,9 @@ public class ContaServiceImplTest {
     @ValueSource(doubles = {-1.0, Double.NaN})
     public void quandoContasCadastrarESaldoForVazioOuNuloEntaoExibaMensagem(Double saldo) {
 
-        Exception exception = assertThrows(Exception.class, () -> {
-            contaServiceImpl.cadastrarConta(CPF_CLIENTE, String.valueOf(saldo));
-
-        });
+        Exception exception = assertThrows(Exception.class, () ->
+                contaServiceImpl.cadastrarConta(CPF_CLIENTE, String.valueOf(saldo))
+        );
         assertEquals("O saldo deve ser um número maior que zero.\n", exception.getMessage());
     }
 
@@ -137,7 +134,8 @@ public class ContaServiceImplTest {
     @Test
     public void quandoContasPesquisarCPFTitularENaoEncontrarEntaoMensagemAdequada() {
         Exception exception = assertThrows(Exception.class, () ->
-                contaServiceImpl.buscarContasPorCPF(CPF_CLIENTE));
+                contaServiceImpl.buscarContasPorCPF(CPF_CLIENTE)
+        );
         assertEquals("Conta não encontrada. Cadastre-se e tente novamente.\n", exception.getMessage());
     }
 


### PR DESCRIPTION
Atualmente, a persistência é gerenciada diretamente pelos Services.

Introduzir uma camada de persistência dedicada para remover essa responsabilidade dos Services:

Criar uma interface de persistência para cada entidade. Ex.: CartaoPersistence

Essa interface deve ser implementada por uma classe. Ex.: InMemoryCartaoPersistence